### PR TITLE
Bug fixes and improvements

### DIFF
--- a/coffeegrinder/src/main/java/org/nineml/coffeegrinder/trees/Arborist.java
+++ b/coffeegrinder/src/main/java/org/nineml/coffeegrinder/trees/Arborist.java
@@ -6,7 +6,9 @@ import org.nineml.coffeegrinder.parser.ParseForest;
 import org.nineml.coffeegrinder.parser.TerminalSymbol;
 import org.nineml.logging.Logger;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -16,6 +18,7 @@ abstract public class Arborist {
     protected final String logcategory = "Lumberjack";
 
     protected final Set<Integer> selectedNodes = new HashSet<>();
+    protected final List<TreeSelection> selectedTrees = new ArrayList<>();
     public final ParseForest forest;
     protected final Logger logger;
     protected boolean ambiguous = false;
@@ -57,6 +60,10 @@ abstract public class Arborist {
 
     public Set<Integer> getSelectedNodes() {
         return new HashSet<>(selectedNodes);
+    }
+
+    public List<TreeSelection> getSelectedTrees() {
+        return selectedTrees;
     }
 
     protected void build(TreeBuilder builder, ParseTree tree) {

--- a/coffeegrinder/src/main/java/org/nineml/coffeegrinder/trees/Axe.java
+++ b/coffeegrinder/src/main/java/org/nineml/coffeegrinder/trees/Axe.java
@@ -23,7 +23,7 @@ public interface Axe {
      * <p>In an ambiguous forest, some nodes will have more than one possible choice. In any given
      * tree, only one choice may be selected. This function is called to make the selection.
      * </p>
-     * <p>There will always be at least elements in the choices list when the method is called.
+     * <p>There will always be at least one element in the choices list when the method is called.
      * The method must return at least one.</p>
      * <p>The first node in the list returned is the choice selected for the tree currently under construction.
      * If only one choice is returned, the node becomes unambiguous on subsequent parses,

--- a/coffeegrinder/src/main/java/org/nineml/coffeegrinder/trees/Lumberjack.java
+++ b/coffeegrinder/src/main/java/org/nineml/coffeegrinder/trees/Lumberjack.java
@@ -93,6 +93,7 @@ public class Lumberjack extends Arborist {
             nextVertex = null;
 
             tree = new ParseTree(forest.getOptions().getMarkAmbiguities());
+            selectedTrees.clear();
             ok = seek(node, parserAttributes, tree);
 
             //System.err.printf("%s %s%n", treeNumber, ok);
@@ -197,6 +198,10 @@ public class Lumberjack extends Arborist {
             choice = vertex.choices.get(choiceIndex);
         } else {
             choice = node.getFamilies().get(0);
+        }
+
+        if (vertex.isAmbiguous) {
+            selectedTrees.add(new TreeSelection(node, tree, choice));
         }
 
         boolean goLeft = choice.getLeftNode() != null;

--- a/coffeegrinder/src/main/java/org/nineml/coffeegrinder/trees/ParseTree.java
+++ b/coffeegrinder/src/main/java/org/nineml/coffeegrinder/trees/ParseTree.java
@@ -109,6 +109,6 @@ public class ParseTree {
         if (vertex == null) {
             return "ROOT";
         }
-        return vertex + " :: " + (left == null ? "" : "L") + (right == null ? "" : "R");
+        return vertex.toString();
     }
 }

--- a/coffeegrinder/src/main/java/org/nineml/coffeegrinder/trees/TreeBuilder.java
+++ b/coffeegrinder/src/main/java/org/nineml/coffeegrinder/trees/TreeBuilder.java
@@ -52,14 +52,18 @@ public interface TreeBuilder {
     void token(Token token, Map<String,String> attributes, int leftExtent, int rightExtent);
 
     /**
-     * Called at the start of an ambiguity that is not marked by a single nonterminal
+     * Called at the start of an ambiguity that is not marked by a single nonterminal.
+     * <p>The ambiguity id will distinguish this ambiguity from any other ambiguity. The numbers are not
+     * sequential or guaranteed stable across parses.</p>
+     * @param id The ambiguity id.
      * @param leftExtent The starting position in the input.
      * @param rightExtent The ending position in the input.
      */
     void startAmbiguity(int id, int leftExtent, int rightExtent);
 
     /**
-     * Called at the end of an ambiguity that is not marked by a single nonterminal
+     * Called at the end of an ambiguity that is not marked by a single nonterminal.
+     * @param id The ambiguity id.
      * @param leftExtent The starting position in the input.
      * @param rightExtent The ending position in the input.
      */

--- a/coffeegrinder/src/main/java/org/nineml/coffeegrinder/trees/TreeSelection.java
+++ b/coffeegrinder/src/main/java/org/nineml/coffeegrinder/trees/TreeSelection.java
@@ -1,0 +1,15 @@
+package org.nineml.coffeegrinder.trees;
+
+import org.nineml.coffeegrinder.parser.Family;
+import org.nineml.coffeegrinder.parser.ForestNode;
+
+public class TreeSelection {
+    public final ForestNode node;
+    public final ParseTree parent;
+    public final Family selection;
+    public TreeSelection(ForestNode node, ParseTree parent, Family selection) {
+        this.node = node;
+        this.parent = parent;
+        this.selection = selection;
+    }
+}

--- a/coffeegrinder/src/main/java/org/nineml/coffeegrinder/trees/TreeSurgeon.java
+++ b/coffeegrinder/src/main/java/org/nineml/coffeegrinder/trees/TreeSurgeon.java
@@ -63,6 +63,7 @@ public class TreeSurgeon extends Arborist {
 
         seenCount.clear();
         selectedNodes.clear();
+        selectedTrees.clear();
         ParseTree tree = new ParseTree(forest.getOptions().getMarkAmbiguities());
         seek(node, parserAttributes, tree);
         build(builder, tree.left);
@@ -114,6 +115,10 @@ public class TreeSurgeon extends Arborist {
             ambiguous = remainingChoices.size() > 1;
         } else {
             choice = node.getFamilies().get(0);
+        }
+
+        if (vertex.isAmbiguous) {
+            selectedTrees.add(new TreeSelection(node, tree, choice));
         }
 
         boolean goLeft = choice.getLeftNode() != null;

--- a/coffeepot/src/main/java/org/nineml/coffeepot/Main.java
+++ b/coffeepot/src/main/java/org/nineml/coffeepot/Main.java
@@ -23,7 +23,6 @@ import java.io.PrintStream;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Calendar;
-import java.util.Set;
 
 /**
  * A command-line Invisible XML parser.
@@ -208,6 +207,9 @@ class Main {
             if (!doc.succeeded()) {
                 break;
             }
+
+            // Passing stderr here is an awful hack; need to rethink
+            outputManager.describeAmbiguity(stderr);
 
             graphOutputManager.publish(doc, outputManager.selectedNodes);
         }
@@ -433,5 +435,4 @@ class Main {
             stderr.printf("%s %ds%s%n", prefix, time, suffix);
         }
     }
-
 }

--- a/coffeepot/src/main/java/org/nineml/coffeepot/managers/Configuration.java
+++ b/coffeepot/src/main/java/org/nineml/coffeepot/managers/Configuration.java
@@ -51,6 +51,7 @@ public class Configuration {
     public final int repeat;
     public final boolean debug;
     public final String axe;
+    public final boolean trim;
 
     public Configuration(String[] args) {
         this(System.out, System.err, args);
@@ -401,6 +402,7 @@ public class Configuration {
         outputFile = cmain.outputFile;
         forest = cmain.forest;
         graph = cmain.graph;
+        trim = cmain.trim;
 
         graphOptions = cmain.graphOptions;
         if (cmain.graphFormat != null) {
@@ -660,6 +662,9 @@ public class Configuration {
 
         @Parameter(names = {"--axe"}, description = "Specify an axe")
         public String axe = null;
+
+        @Parameter(names = {"--trim"}, description = "Trim leading and trailing whitespace on input")
+        public boolean trim = false;
 
         @Parameter(description = "The input")
         public List<String> inputText = new ArrayList<>();

--- a/coffeepot/src/main/java/org/nineml/coffeepot/managers/Configuration.java
+++ b/coffeepot/src/main/java/org/nineml/coffeepot/managers/Configuration.java
@@ -191,10 +191,7 @@ public class Configuration {
                 describeAmbiguityWith = "none";
             }
         } else {
-            if ("apixml".equals(cmain.describeAmbiguityWith)) {
-                cmain.describeAmbiguityWith = "api-xml";
-            }
-            if ("xml".equals(cmain.describeAmbiguityWith) || "api-xml".equals(cmain.describeAmbiguityWith)) {
+            if ("xml".equals(cmain.describeAmbiguityWith)) {
                 if (processor == null) {
                     options.getLogger().error(logcategory, "Cannot describe ambiguity with XML, no Saxon processor available");
                     describeAmbiguityWith = "none";

--- a/coffeepot/src/main/java/org/nineml/coffeepot/managers/Configuration.java
+++ b/coffeepot/src/main/java/org/nineml/coffeepot/managers/Configuration.java
@@ -50,6 +50,7 @@ public class Configuration {
     public final boolean omitCsvHeaders;
     public final int repeat;
     public final boolean debug;
+    public final String axe;
 
     public Configuration(String[] args) {
         this(System.out, System.err, args);
@@ -355,6 +356,34 @@ public class Configuration {
             options.enablePragma(pragma);
         }
 
+        if (cmain.axe == null) {
+            axe = "xpath";
+        } else {
+            if ("xpath".equals(cmain.axe) || "random".equals(cmain.axe)
+                    || "priority".equals(cmain.axe) || "sequential".equals(cmain.axe)) {
+                axe = cmain.axe;
+
+                if ("sequential".equals(axe)) {
+                    options.getLogger().debug(logcategory, "Disabling priority pragma for sequential axe");
+                    options.disablePragma("priority");
+                }
+            } else {
+                options.getLogger().error(logcategory, "Unknown axe type: %s", cmain.axe);
+                axe = "xpath";
+            }
+        }
+
+        if ("random".equals(axe) && (cmain.functionLibrary != null || !cmain.choose.isEmpty())) {
+            if (cmain.functionLibrary != null) {
+                options.getLogger().error(logcategory, "The --function-library option is incompatible with the %s axe", axe);
+                cmain.functionLibrary = null;
+            }
+            if (!cmain.choose.isEmpty()) {
+                options.getLogger().error(logcategory, "The --choose option is incompatible with the %s axe", axe);
+                cmain.choose.clear();
+            }
+        }
+
         grammar = cmain.grammar;
         timing = cmain.timing;
         timeRecords = cmain.timeRecords;
@@ -628,6 +657,9 @@ public class Configuration {
 
         @Parameter(names = {"--start-symbol", "--start"}, description = "Specify the start symbol")
         public String startSymbol = null;
+
+        @Parameter(names = {"--axe"}, description = "Specify an axe")
+        public String axe = null;
 
         @Parameter(description = "The input")
         public List<String> inputText = new ArrayList<>();

--- a/coffeepot/src/main/java/org/nineml/coffeepot/managers/InputManager.java
+++ b/coffeepot/src/main/java/org/nineml/coffeepot/managers/InputManager.java
@@ -55,9 +55,9 @@ public class InputManager {
                 sb.append((char) inputchar);
                 inputchar = reader.read();
             }
-            input = sb.toString();
+            input = config.trim ? sb.toString().trim() : sb.toString();
         } else {
-            input = config.input;
+            input = config.trim ? config.input.trim() : config.input;
         }
 
         inputSize = input.length();

--- a/coffeepot/src/main/java/org/nineml/coffeepot/trees/VerboseAxe.java
+++ b/coffeepot/src/main/java/org/nineml/coffeepot/trees/VerboseAxe.java
@@ -41,14 +41,8 @@ import java.util.*;
 public class VerboseAxe extends PriorityAxe {
     public static final String logcategory = "CoffeePot";
 
-    private static final QName _name = new QName("name");
-    private static final QName _value = new QName("value");
-    private static final QName _symbol = new QName("symbol");
     private static final QName _id = new QName("id");
     private static final QName _children = new QName("children");
-    private static final QName _start = new QName("start");
-    private static final QName _length = new QName("length");
-    private static final QName _priority = new QName("priority");
 
     public static final XdmAtomicValue _input = new XdmAtomicValue("input");
     public static final XdmAtomicValue _forest = new XdmAtomicValue("forest");
@@ -60,7 +54,6 @@ public class VerboseAxe extends PriorityAxe {
     private static final QName _options = new QName("options");
     public static final String CPNS = "https://coffeepot.nineml.org/ns/functions";
     public static final StructuredQName CP_CHOOSE = new StructuredQName("cp", CPNS, "choose-alternative");
-    private final Configuration config;
     private final Processor processor;
     private final XmlForest forest;
     private final ParserOptions options;
@@ -72,7 +65,6 @@ public class VerboseAxe extends PriorityAxe {
     private boolean madeAmbiguousChoice = false;
 
     public VerboseAxe(Configuration config, InvisibleXmlParser parser, InvisibleXmlDocument document, String input) {
-        this.config = config;
         this.processor = config.processor;
         this.options = config.options;
         this.input = new XdmAtomicValue(input);
@@ -185,11 +177,6 @@ public class VerboseAxe extends PriorityAxe {
     }
 
     @Override
-    public boolean isSpecialist() {
-        return false;
-    }
-
-    @Override
     public List<Family> select(ParseTree tree, ForestNode forestNode, int count, List<Family> choices) {
         lastChoiceWasAmbiguous = false;
         List<Family> selected = new ArrayList<>();
@@ -199,14 +186,8 @@ public class VerboseAxe extends PriorityAxe {
             choiceMap.put("C" + choice.id, choice);
         }
 
-        final XdmNode node;
+        final XdmNode node = getAmbiguityContext(choices.get(0));
         try {
-            XPathCompiler compiler = processor.newXPathCompiler();
-            XPathExecutable exec = compiler.compile(String.format("//children[@id='C%d']/parent::symbol", choices.get(0).id));
-            XPathSelector selector = exec.load();
-            selector.setContextItem(forest.getXml());
-            node = (XdmNode) selector.evaluateSingle();
-
             XdmMap map = new XdmMap();
             map = map.put(_forest, forest.getXml());
             map = map.put(_input, input);
@@ -223,8 +204,9 @@ public class VerboseAxe extends PriorityAxe {
 
             if (functionLibrary == null) {
                 for (String expr : expressions) {
-                    exec = compiler.compile(expr);
-                    selector = exec.load();
+                    XPathCompiler compiler = processor.newXPathCompiler();
+                    XPathExecutable exec = compiler.compile(expr);
+                    XPathSelector selector = exec.load();
 
                     selector.setContextItem(node);
                     XdmValue selection = selector.evaluate();
@@ -259,11 +241,12 @@ public class VerboseAxe extends PriorityAxe {
                     options.getLogger().debug("Expression %s did not make a selection", expr);
                 }
             } else  {
+                XPathCompiler compiler = processor.newXPathCompiler();
                 compiler.declareNamespace("f", "https://coffeepot.nineml.org/ns/functions");
                 compiler.declareVariable(_context);
                 compiler.declareVariable(_options);
-                exec = compiler.compile("f:choose-alternative($context, $options)");
-                selector = exec.load();
+                XPathExecutable exec = compiler.compile("f:choose-alternative($context, $options)");
+                XPathSelector selector = exec.load();
                 selector.setVariable(_context, node);
                 selector.setVariable(_options, map);
                 Map<XdmAtomicValue,XdmValue> newMap = selector.evaluateSingle().asMap();
@@ -306,116 +289,7 @@ public class VerboseAxe extends PriorityAxe {
             madeAmbiguousChoice = madeAmbiguousChoice || lastChoiceWasAmbiguous;
         }
 
-        switch (config.describeAmbiguityWith) {
-            case "text":
-                textAmbiguity(tree, node, selected.get(0));
-                break;
-            case "api-xml":
-            case "xml":
-                xmlAmbiguity(tree, node, selected.get(0));
-                break;
-            default:
-                break;
-        }
-
         return selected;
-    }
-
-    private void textAmbiguity(ParseTree tree, XdmNode node, Family selection) {
-        config.stdout.println(choiceContext(tree));
-
-        String lhs = node.getAttributeValue(_name);
-
-        final String nocheck = "        ";
-        final String check;
-        final String lquo;
-        final String rquo;
-        final String arrow;
-        if (config.options.getAsciiOnly()) {
-            check = "      X ";
-            lquo = " (";
-            rquo = ")";
-            arrow = " => ";
-        } else {
-            check = "      ✔ ";
-            lquo = " «";
-            rquo = "»";
-            arrow = " ⇒ ";
-        }
-
-        String id = "C" + selection.id;
-        XdmSequenceIterator<XdmNode> childrenIterator = node.axisIterator(Axis.CHILD, _children);
-        while (childrenIterator.hasNext()) {
-            XdmNode children = childrenIterator.next();
-
-            StringBuilder sb = new StringBuilder();
-            if (id.equals(children.getAttributeValue(_id))) {
-                sb.append(check);
-            } else {
-                sb.append(nocheck);
-            }
-            sb.append(lhs).append(lquo).append(node.getAttributeValue(_start));
-            sb.append(",").append(node.getAttributeValue(_length));
-            sb.append(rquo);
-            if (!"0".equals(children.getAttributeValue(_priority))) {
-                sb.append("/").append(children.getAttributeValue(_priority));
-            }
-            sb.append(arrow);
-
-            boolean first = true;
-            XdmSequenceIterator<XdmNode> childIterator = children.axisIterator(Axis.CHILD);
-            while (childIterator.hasNext()) {
-                XdmNode child = childIterator.next();
-                if (!first){
-                    sb.append(", ");
-                }
-                if (_symbol.equals(child.getNodeName())) {
-                    sb.append(child.getAttributeValue(_name));
-                } else {
-                    sb.append(child.getAttributeValue(_value));
-                }
-                first = false;
-            }
-
-            config.stdout.println(sb);
-        }
-    }
-
-    private void xmlAmbiguity(ParseTree tree, XdmNode node, Family selection) {
-        config.stdout.printf("%s (selected C%s)%n", choiceContext(tree), selection.id);
-        config.stdout.println(node);
-    }
-
-    private String choiceContext(ParseTree tree) {
-        ArrayList<String> segments = new ArrayList<>();
-        // Work my way backwards up the tree...
-        ParseTree branch = tree;
-        String name = tree.vertex.node.symbol.toString();
-        while (branch.parent != null) {
-            int count = 0;
-            for (ParseTree child : branch.getChildren()) {
-                if (child.vertex.node.symbol != null) {
-                    count++; // bogus bogus bogus
-                }
-            }
-            branch = branch.parent;
-        }
-
-        /*
-        StringBuilder sb = new StringBuilder();
-        sb.append("At ");
-        for (int pos = 0; pos < symbolStack.size(); pos++) {
-            String name = symbolStack.get(pos);
-            sb.append("/").append(name);
-            sb.append("[");
-            sb.append(countStack.get(pos));
-            sb.append("]");
-        }
-        return sb.toString();
-
-         */
-
-        return "BROKEN";
     }
 
     @Override
@@ -426,5 +300,24 @@ public class VerboseAxe extends PriorityAxe {
     @Override
     public void forArborist(Arborist arborist) {
         // nop
+    }
+
+    public XdmNode getAmbiguityContext(Family choice) {
+        try {
+            XPathCompiler compiler = processor.newXPathCompiler();
+            XPathExecutable exec = compiler.compile(String.format("//children[@id='C%d']/parent::*", choice.id));
+            XPathSelector selector = exec.load();
+            selector.setContextItem(forest.getXml());
+            XdmNode parentNode = (XdmNode) selector.evaluateSingle();
+            if (parentNode == null) {
+                exec = compiler.compile(String.format("//*[@id='N%d']", choice.id));
+                selector = exec.load();
+                selector.setContextItem(forest.getXml());
+                parentNode = (XdmNode) selector.evaluateSingle();
+            }
+            return parentNode;
+        } catch (SaxonApiException ex) {
+            throw new RuntimeException(ex);
+        }
     }
 }

--- a/coffeepot/src/main/java/org/nineml/coffeepot/utils/NodeUtils.java
+++ b/coffeepot/src/main/java/org/nineml/coffeepot/utils/NodeUtils.java
@@ -1,0 +1,27 @@
+package org.nineml.coffeepot.utils;
+
+import net.sf.saxon.s9api.*;
+import org.nineml.coffeegrinder.parser.Family;
+import org.nineml.coffeesacks.XmlForest;
+
+public class NodeUtils {
+    public static XdmNode getAmbiguityContext(Processor processor, XmlForest forest, Family choice) {
+        try {
+            XPathCompiler compiler = processor.newXPathCompiler();
+            XPathExecutable exec = compiler.compile(String.format("//children[@id='C%d']/parent::*", choice.id));
+            XPathSelector selector = exec.load();
+            selector.setContextItem(forest.getXml());
+            XdmNode parentNode = (XdmNode) selector.evaluateSingle();
+            if (parentNode == null) {
+                exec = compiler.compile(String.format("//*[@id='N%d']", choice.id));
+                selector = exec.load();
+                selector.setContextItem(forest.getXml());
+                parentNode = (XdmNode) selector.evaluateSingle();
+            }
+            return parentNode;
+        } catch (SaxonApiException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+}

--- a/coffeepot/src/test/java/org/nineml/coffeepot/CoffeePotTest.java
+++ b/coffeepot/src/test/java/org/nineml/coffeepot/CoffeePotTest.java
@@ -20,7 +20,8 @@ public class CoffeePotTest {
             }
         }
         public boolean contains(String target) {
-            return toString().contains(target);
+            String lines = toString();
+            return lines.contains(target);
         }
     }
 }

--- a/coffeepot/src/test/java/org/nineml/coffeepot/MainTest.java
+++ b/coffeepot/src/test/java/org/nineml/coffeepot/MainTest.java
@@ -84,7 +84,7 @@ public class MainTest extends CoffeePotTest {
         Main main = new Main();
         try {
             OutputManager manager = main.commandLine(new String[] {"-g:src/test/resources/smoke.ixml", "a", "--no-output"});
-            Assertions.assertEquals(1, manager.stringRecords.size());
+            Assertions.assertEquals(0, manager.stringRecords.size());
             Assertions.assertEquals("", manager.publication());
         } catch (Exception ex) {
             fail();
@@ -143,7 +143,7 @@ public class MainTest extends CoffeePotTest {
         try {
             OutputManager manager = main.commandLine(new String[] {"-g:src/test/resources/ambig2.ixml", "--describe-ambiguity", "x" });
             Assertions.assertEquals(1, manager.stringRecords.size());
-            Assertions.assertTrue(stdout.contains("✔ S «1,1» ⇒ 'x'"));
+            Assertions.assertTrue(stderr.contains("✔ 'x'«1-1»"));
         } catch (Exception ex) {
             fail();
         }

--- a/coffeepot/src/test/java/org/nineml/coffeepot/XPathChoiceTest.java
+++ b/coffeepot/src/test/java/org/nineml/coffeepot/XPathChoiceTest.java
@@ -13,25 +13,14 @@ public class XPathChoiceTest extends CoffeePotTest {
         WrappedPrintStream stderr = new WrappedPrintStream();
         Main main = new Main(stdout.stream, stderr.stream);
         try {
-            OutputManager manager = main.commandLine(new String[] {"-g:src/test/resources/ambig2.ixml", "--describe-ambiguity-with:xml",
+            OutputManager manager = main.commandLine(new String[] {"-g:src/test/resources/ambig2.ixml", "--describe-ambiguity",
                     "--choose:children[symbol[@name='B']]", "x" });
             Assertions.assertEquals(1, manager.stringRecords.size());
             Assertions.assertEquals("<S><B>x</B></S>", manager.stringRecords.get(0));
             Assertions.assertTrue(stderr.contains("Found 3 possible parses"));
 
-            String output = stdout.toString();
-            int pos = output.indexOf("C");
-            String selected = output.substring(pos);
-            pos = selected.indexOf(")");
-            selected = selected.substring(0, pos);
-
-            pos = output.indexOf(String.format("<children id=\"%s\"", selected));
-            output = output.substring(pos);
-
-            pos = output.indexOf("<symbol");
-            output = output.substring(pos);
-
-            Assertions.assertTrue(output.startsWith("<symbol name=\"B\""));
+            String output = stderr.toString();
+            Assertions.assertTrue(output.contains("✔ B«1-1»"));
         } catch (Exception ex) {
             fail();
         }
@@ -43,25 +32,14 @@ public class XPathChoiceTest extends CoffeePotTest {
         WrappedPrintStream stderr = new WrappedPrintStream();
         Main main = new Main(stdout.stream, stderr.stream);
         try {
-            OutputManager manager = main.commandLine(new String[] {"-g:src/test/resources/ambig2.ixml", "--describe-ambiguity-with:xml",
+            OutputManager manager = main.commandLine(new String[] {"-g:src/test/resources/ambig2.ixml", "--describe-ambiguity",
                     "--choose:children[symbol[@name='B']]/@id", "x" });
             Assertions.assertEquals(1, manager.stringRecords.size());
             Assertions.assertEquals("<S><B>x</B></S>", manager.stringRecords.get(0));
             Assertions.assertTrue(stderr.contains("Found 3 possible parses"));
 
-            String output = stdout.toString();
-            int pos = output.indexOf("C");
-            String selected = output.substring(pos);
-            pos = selected.indexOf(")");
-            selected = selected.substring(0, pos);
-
-            pos = output.indexOf(String.format("<children id=\"%s\"", selected));
-            output = output.substring(pos);
-
-            pos = output.indexOf("<symbol");
-            output = output.substring(pos);
-
-            Assertions.assertTrue(output.startsWith("<symbol name=\"B\""));
+            String output = stderr.toString();
+            Assertions.assertTrue(output.contains("✔ B«1-1»"));
         } catch (Exception ex) {
             fail();
         }

--- a/coffeepot/src/website/xml/ambiguity.xml
+++ b/coffeepot/src/website/xml/ambiguity.xml
@@ -64,11 +64,11 @@ all with <option>--parse-count:all</option>:</para>
 <programlisting linenumbering="unnumbered"
 ><![CDATA[$ coffeepot -pp -g:examples/ambig01.ixml --describe-ambiguity --no-output Shimmer
 Found 2 possible parses.
-At /$$[1]
-      ✔ product «1,7» ⇒ dessert-topping
-        product «1,7» ⇒ floor-wax]]></programlisting>
+At /product
+    ✔ floor-wax«1-7»
+      dessert-topping«1-7»]]></programlisting>
 
-<para>This indicates that the characters from 1 to 8 in the input can be matched
+<para>This indicates that the characters from 1 to 7 in the input can be matched
 as a <literal>product</literal> containing a <literal>dessert-topping</literal> or
 a <literal>floor-wax</literal>. This is another case where the forest graph
 can be useful.</para>
@@ -91,10 +91,7 @@ this trivial grammar:</para>
   >expr: expr ; 'a' .</programlisting>
 </example>
 
-<para>There’s no practical way for
-<application>coffeepot</application> to enumerate infinitely many
-parses, so it essentially ignores edges in the graph if it encounters
-them a second time. Parsing “a” yields:</para>
+<para>Parsing “a” yields:</para>
 
 <programlisting linenumbering="unnumbered"
 ><![CDATA[$ coffeepot -pp -g:examples/ambig02.ixml a
@@ -107,9 +104,9 @@ the ambiguity, reveals that there are infinitely many parses:</para>
 <programlisting linenumbering="unnumbered"
 ><![CDATA[$ coffeepot -pp -g:examples/ambig02.ixml --describe-ambiguity --no-output a
 Found 2 possible parses (of infinitely many).
-At /$$[1]
-      ✔ expr «1,1» ⇒ 'a'
-        expr «1,1» ⇒ expr]]></programlisting>
+At /expr
+      expr«1-1»
+    ✔ 'a'«1-1»]]></programlisting>
 
 <para>This is also evident in the graph:</para>
 
@@ -122,26 +119,38 @@ At /$$[1]
 </mediaobject>
 </figure>
 
-<para>That loop is the source of infinite ambiguity. The parses that
-<application>coffeepot</application> will enumerate are:</para>
+<para>That loop is the source of infinite ambiguity. Subject to limitations of
+memory and time,
+<application>coffeepot</application> will enumerate an arbitrary number of them:</para>
 
 <programlisting linenumbering="unnumbered"
-><![CDATA[$ coffeepot -pp -g:examples/ambig02.ixml --parse-count:all a
+><![CDATA[$ coffeepot -pp -g:examples/ambig02.ixml --parse-count:4 a
 Found 2 possible parses (of infinitely many).
-<ixml parses="2" totalParses="2" infinitelyAmbiguous="true">
-<expr xmlns:ixml="http://invisiblexml.org/NS" ixml:state="ambiguous">a</expr>
-<expr xmlns:ixml="http://invisiblexml.org/NS" ixml:state="ambiguous">
+<ixml parses="4" totalParses="4" infinitelyAmbiguous="true">
+<expr xmlns:ixml='http://invisiblexml.org/NS' ixml:state='ambiguous'>a</expr>
+<expr xmlns:ixml='http://invisiblexml.org/NS' ixml:state='ambiguous'>
    <expr>a</expr>
+</expr>
+<expr xmlns:ixml='http://invisiblexml.org/NS' ixml:state='ambiguous'>
+   <expr>
+      <expr>a</expr>
+   </expr>
+</expr>
+<expr xmlns:ixml='http://invisiblexml.org/NS' ixml:state='ambiguous'>
+   <expr>
+      <expr>
+         <expr>a</expr>
+      </expr>
+   </expr>
 </expr>
 </ixml>
 ]]></programlisting>
 
 <para>The default “sequential” tree selector will choose every node
-and ever edge at least once. For graphs without loops, this matches
+and every edge at least once. For graphs without loops, this matches
 the number of parses reported. Tree construction from graphs that
 contain loops is challenging. The total number of parses reported does
-not take loops into consideration. The tree selector tries to follow
-all of the paths once, but it may not always succeed. Consider:</para>
+not take loops into consideration. Consider:</para>
 
 <programlisting language="ixml"><xi:include href="examples/horror.ixml" parse="text"/></programlisting>
 
@@ -172,12 +181,6 @@ But the graph is pernicously looped:</para>
 </mediaobject>
 </figure>
 
-<para>Asking for <emphasis>all</emphasis> of the parses will return 57 different parses.
-That’s not all of them, even by the criteria that
-<productname>coffeepot</productname> is using. The processor tries to follow
-all of the unique paths, but also tries to avoid falling into an
-infinite loop.</para>
-
 <para>The priority tree selector will always choose the path with the
 highest priority (if there is one). If all choices are made by a
 uniquely highest priority in each case, this fact is recorded.
@@ -192,8 +195,8 @@ make sure it isn’t possible for it to match in two different places.
 <section xml:id="describe-ambiguity">
 <title>Describing ambiguity</title>
 
-<para>Ambiguity can be described in one of three ways: using a compact, text format;
-using a minimal XML format; or using the full XML format that will be used when
+<para>Ambiguity can be described in two ways: using a compact, text format or
+using the full XML format that will be used when
 <link xlink:href="choose-alternative">choosing alternatives</link> with a function or
 XPath expression.</para>
 
@@ -204,91 +207,48 @@ introduced in <xref linkend="choose-alternative"/>.</para>
 <title>Textual ambiguity descriptions</title>
 <para>The text format identifies the location in the result tree with a simple XPath
 expression and then lists each option in the form “nonterminal =&gt; right-hand-side”.
-An “X” marks the selected alternative.</para>
+An “✔” marks the selected alternative.</para>
 
 <para>For example:</para>
 
-<programlisting><![CDATA[At /$$[1]/number-list[1]/$1_number-plus[3]
-      ✔ number «10,2» ⇒ hex
-        number «10,2» ⇒ decimal]]></programlisting>
+<programlisting><![CDATA[At /number-list/number
+    ✔ decimal«10-11»
+      hex«10-11»]]></programlisting>
 
-<para>This indicates that at the “number” element, in the third item of the number list,
-there are two choices “hex” or “decimal”.
-Both span input tokens 10-11. The “hex” alternative has been selected.
+<para>This indicates that at the “number” element in the number list,
+there are two choices, “hex” or “decimal”.
+Both span input tokens 10-11. The “decimal” alternative has been selected.
 </para>
 </section>
 
 <section xml:id="describe-xml">
 <title>XML ambiguity descriptions</title>
-<para>The XML format presents the same information in a small XML
+<para>The XML format presents the same information in a XML
 fragments that represent the parse trees under consideration.</para>
 
 <para>For example:</para>
 
-<programlisting><![CDATA[At /$$[1]/number-list[1]/$1_number-plus[3] (selected C3464)
-<symbol name="number" id="N3694" mark="^" start="10" length="2">
-   <parent ref="N3699">$1_number-plus</parent>
-   <children id="C3464" priority="0">
-      <symbol name="hex" ref="N3692" start="10" length="2"/>
-   </children>
-   <children id="C3465" priority="0">
-      <symbol name="decimal" ref="N3693" start="10" length="2"/>
-   </children>
-</symbol>]]></programlisting>
+<programlisting><![CDATA[At /number-list/number
+           <symbol name="number"
+                   id="N40"
+                   mark="^"
+                   start="10"
+                   end="11"
+                   length="2">
+              <parent ref="N22">$8_number-option</parent>
+<!-- ✔ -->    <children id="C20">
+                 <symbol name="decimal" ref="N49" start="10" end="11" length="2"/>
+              </children>
+              <children id="C21">
+                 <symbol name="hex" ref="N51" start="10" end="11" length="2"/>
+              </children>
+           </symbol>]]></programlisting>
 
 <para>As before, this indicates that at the “number” element,
 there are two choices, represented by separate <tag>children</tag> elements.
 </para>
 </section>
 
-<!--
-<section xml:id="describe-api-xml">
-<title>API XML ambiguity descriptions</title>
-<para>The “API” XML format is designed to provide as much information as possible
-such that it’s easy to write XPath expressions to analyze it. The result is somewhat
-less easy to read.</para>
-
-<para>These are the XML alternatives that function libraries and XPath expressions are
-evaluated against. Here, the entire document is shown, but the actual context item
-in each case is the element with the <tag class="attribute">alternative</tag> attribute.
-</para>
-
-<para>For example:</para>
-
-<programlisting><![CDATA[At /number-list[1]/number[3]
-Alternative 1 of 2 (selected):
-<number-list xmlns:a="https://nineml.org/ns/describe-ambiguity"
-              a:version="1.0"
-              name="number-list"
-              mark="^">
-   <number name="number"/>
-   <number name="number"/>
-   <number alternative="1" name="number" from="9" to="11" mark="-">
-      <hex name="hex" from="9" to="11" mark="^">
-         <a:nonterminal name="$2_hex-digit-plus" mark="-">…</a:nonterminal>
-      </hex>
-   </number>
-</number-list>
-Alternative 2 of 2:
-<number-list xmlns:a="https://nineml.org/ns/describe-ambiguity"
-              a:version="1.0"
-              name="number-list"
-              mark="^">
-   <number name="number"/>
-   <number name="number"/>
-   <number alternative="2" name="number" from="9" to="11" mark="-">
-      <decimal name="decimal" from="9" to="11" mark="^">
-         <a:nonterminal name="$3_decimal-digit-plus" mark="-">…</a:nonterminal>
-      </decimal>
-   </number>
-</number-list>]]></programlisting>
-
-<para>As before, this indicates that at the third “number” element,
-there are two choices “hex” or “decimal” and the first choice has been selected.
-</para>
-
-</section>
--->
 </section>
 
 </chapter>

--- a/coffeepot/src/website/xml/cli.xml
+++ b/coffeepot/src/website/xml/cli.xml
@@ -103,6 +103,21 @@ that contain a large number of characters such as <code>[L]</code> or
 <code>[LC]</code>.</para>
 </listitem>
 </varlistentry>
+<varlistentry xml:id="_axe">
+<term><option>--axe:<replaceable>axe-type</replaceable></option></term>
+<listitem>
+<para>Specifies a different “axe type” for getting trees out of the forest.
+The default axe type is <literal>xpath</literal>. If neither a function library
+nor XPath expressions are provided, this axe considers
+priorities, so it’s the same as the <literal>priority</literal> axe. The
+<literal>sequential</literal> axe disables the priority pragma. The
+<literal>random</literal> axe makes a random choice at every ambiguity. For graphs with
+infinite ambiguity, this is only very likely to find a tree, not guaranteed.</para>
+<para>The <literal>random</literal> axe is incompatible with the
+<option>--function-library</option> and <option>--choose</option> options, they’re
+ignored if you specify a random axe.</para>
+</listitem>
+</varlistentry>
 <varlistentry xml:id="_bnf">
 <term><option>--bnf</option></term>
 <listitem>
@@ -110,7 +125,7 @@ that contain a large number of characters such as <code>[L]</code> or
 changer the parser, it simply reports if the grammar is BNF. (Why?
 Well, if you’re interested in exploring a tool like the ambiguity
 analyzer, the results can be easier to understand if the input grammar hasn’t been
-transformed in any way. This option let’s you check if that’s the case.)
+transformed in any way. This option let’s you check if that will be the case.)
 </para>
 </listitem>
 </varlistentry>
@@ -149,7 +164,7 @@ This option only applies to ambiguous parses. See also, <xref linkend="describe-
 <listitem>
 <para>Selects how ambiguity will be described. Implies <option>--describe-ambiguity</option>.
 </para>
-<para>The options are <code>text</code>, <code>xml</code>, and <code>api-xml</code>.
+<para>The options are <code>text</code> or <code>xml</code>.
 See <xref linkend="describe-ambiguity"/>.
 </para>
 </listitem>

--- a/coffeepot/src/website/xml/cli.xml
+++ b/coffeepot/src/website/xml/cli.xml
@@ -492,6 +492,13 @@ and <code>prefix</code> states can be suppressed.
 </para>
 </listitem>
 </varlistentry>
+<varlistentry xml:id="_trim">
+<term><option>--trim</option></term>
+<listitem>
+<para>Trim leading and trailing whitespace from the input before parsing it.
+</para>
+</listitem>
+</varlistentry>
 <varlistentry xml:id="_unbuffered">
 <term><option>--unbuffered</option></term>
 <listitem>

--- a/coffeesacks/src/main/java/org/nineml/coffeesacks/XmlForest.java
+++ b/coffeesacks/src/main/java/org/nineml/coffeesacks/XmlForest.java
@@ -90,12 +90,16 @@ public class XmlForest {
 
         AttributeBuilder atts;
         HashSet<ForestNode> processed = new HashSet<>();
+        HashSet<ForestNode> queued = new HashSet<>();
         ArrayList<ForestNode> toBeProcessed = new ArrayList<>();
         toBeProcessed.add(root);
 
         while (!toBeProcessed.isEmpty()) {
             ForestNode node = toBeProcessed.remove(0);
             processed.add(node);
+            queued.remove(node);
+
+            //System.err.printf("Node: %s%n", node);
 
             final String gi;
             if (node.symbol instanceof TerminalSymbol) {
@@ -167,8 +171,9 @@ public class XmlForest {
                     atts.addAttribute("", "length", String.valueOf(child.rightExtent - child.leftExtent));
                     handler.startElement("", childgi, childgi, atts);
                     handler.endElement("", childgi, childgi);
-                    if (!processed.contains(child)) {
+                    if (!processed.contains(child) && !queued.contains(child)) {
                         toBeProcessed.add(child);
+                        queued.add(child);
                     }
                 }
                 handler.endElement("", "children", "children");

--- a/coffeesacks/src/main/java/org/nineml/coffeesacks/XmlForest.java
+++ b/coffeesacks/src/main/java/org/nineml/coffeesacks/XmlForest.java
@@ -30,6 +30,10 @@ public class XmlForest {
     private BuildingContentHandler handler;
     protected final Map<String,XdmNode> choiceIndex = new HashMap<>();
     private XdmNode doc;
+    HashSet<ForestNode> processed = null;
+    HashSet<ForestNode> queued = null;
+    ArrayList<ForestNode> toBeProcessed = null;
+
 
     public XmlForest(Processor processor, InvisibleXmlDocument document) throws SaxonApiException, SAXException {
         this.processor = processor;
@@ -85,7 +89,123 @@ public class XmlForest {
         }
     }
 
-    private void buildXmlRepresentation(ForestNode root) throws SAXException {
+    private synchronized void buildXmlRepresentation(ForestNode root) throws SAXException {
+        processed = new HashSet<>();
+        queued = new HashSet<>();
+        toBeProcessed = new ArrayList<>();
+
+        traverse(root, Collections.emptyList());
+
+        AttributeBuilder atts;
+        toBeProcessed.add(root);
+
+        while (!toBeProcessed.isEmpty()) {
+            ForestNode node = toBeProcessed.remove(0);
+            processed.add(node);
+            queued.remove(node);
+
+            //System.err.printf("Node: %s%n", node);
+
+            final String gi;
+            if (node.symbol instanceof TerminalSymbol) {
+                atts = newAttributes("value", node.symbol.toString());
+                atts.addAttribute("id", "N" + node.id);
+                gi = "token";
+            } else {
+                atts = newAttributes("name", ((NonterminalSymbol) node.symbol).getName());
+                atts.addAttribute("id", "N" + node.id);
+                gi = "symbol";
+            }
+
+            String mark = parseAttrMap.get(node).getOrDefault(InvisibleXml.MARK_ATTRIBUTE,
+                parseAttrMap.get(node).getOrDefault(InvisibleXml.TMARK_ATTRIBUTE, null));
+            if (mark != null) {
+                atts.addAttribute("mark", mark);
+            }
+
+            atts.addAttribute("", "start", String.valueOf(node.leftExtent+1));
+            atts.addAttribute("", "end", String.valueOf(node.rightExtent));
+            atts.addAttribute("", "length", String.valueOf(node.rightExtent - node.leftExtent));
+            handler.startElement("", gi, gi, atts);
+
+            for (String key : parseAttrMap.get(node).keySet()) {
+                if (!InvisibleXml.NAME_ATTRIBUTE.equals(key)
+                        && !InvisibleXml.MARK_ATTRIBUTE.equals(key)
+                        && !InvisibleXml.TMARK_ATTRIBUTE.equals(key)) {
+                    atts = newAttributes("name", key);
+                    atts.addAttribute("value", parseAttrMap.get(node).get(key));
+                    handler.startElement("", "attribute", "attribute", atts);
+                    handler.endElement("", "attribute", "attribute");
+                }
+            }
+
+            if (parents.containsKey(node)) {
+                for (ForestNode parent : parents.get(node)) {
+                    atts = newAttributes("ref", "N" + parent.id);
+                    handler.startElement("", "parent", "parent", atts);
+                    char[] chars = ((NonterminalSymbol) parent.symbol).getName().toCharArray();
+                    handler.characters(chars, 0, chars.length);
+                    handler.endElement("", "parent", "parent");
+                }
+            }
+
+            for (Family family : node.getFamilies()) {
+                atts = newAttributes("id", "C" + family.id);
+                handler.startElement("", "children", "children", atts);
+
+                addChild(family.getLeftNode());
+                addChild(family.getRightNode());
+
+                handler.endElement("", "children", "children");
+            }
+
+            handler.endElement("", gi, gi);
+        }
+    }
+
+    private void addChild(ForestNode child) throws SAXException {
+        if (child == null) {
+            return;
+        }
+
+        if (child.symbol != null && !processed.contains(child) && !queued.contains(child)) {
+            toBeProcessed.add(child);
+            queued.add(child);
+        }
+
+        AttributeBuilder atts;
+        final String childgi;
+        if (child.symbol == null) {
+            atts = newAttributes("id", "N" + child.id);
+            childgi = "state";
+        } else if (child.symbol instanceof TerminalSymbol) {
+            atts = newAttributes("value", child.symbol.toString());
+            atts.addAttribute("ref", "N" + child.id);
+            childgi = "token";
+        } else {
+            atts = newAttributes("name", ((NonterminalSymbol) child.symbol).getName());
+            atts.addAttribute("ref", "N" + child.id);
+            childgi = "symbol";
+        }
+        atts.addAttribute("", "start", String.valueOf(child.leftExtent+1));
+        atts.addAttribute("", "end", String.valueOf(child.rightExtent));
+        atts.addAttribute("", "length", String.valueOf(child.rightExtent - child.leftExtent));
+        handler.startElement("", childgi, childgi, atts);
+
+        if (child.symbol == null) {
+            for (Family family : child.getFamilies()) {
+                atts = newAttributes("id", "C" + family.id);
+                handler.startElement("", "children", "children", atts);
+                addChild(family.getLeftNode());
+                addChild(family.getRightNode());
+                handler.endElement("", "children", "children");
+            }
+        }
+
+        handler.endElement("", childgi, childgi);
+    }
+
+    private void xbuildXmlRepresentation(ForestNode root) throws SAXException {
         traverse(root, Collections.emptyList());
 
         AttributeBuilder atts;
@@ -104,7 +224,7 @@ public class XmlForest {
             final String gi;
             if (node.symbol instanceof TerminalSymbol) {
                 atts = newAttributes("value", node.symbol.toString());
-                atts.addAttribute("id", "T" + node.id);
+                atts.addAttribute("id", "N" + node.id);
                 gi = "token";
             } else {
                 atts = newAttributes("name", ((NonterminalSymbol) node.symbol).getName());
@@ -113,12 +233,13 @@ public class XmlForest {
             }
 
             String mark = parseAttrMap.get(node).getOrDefault(InvisibleXml.MARK_ATTRIBUTE,
-                parseAttrMap.get(node).getOrDefault(InvisibleXml.TMARK_ATTRIBUTE, null));
+                    parseAttrMap.get(node).getOrDefault(InvisibleXml.TMARK_ATTRIBUTE, null));
             if (mark != null) {
                 atts.addAttribute("mark", mark);
             }
 
             atts.addAttribute("", "start", String.valueOf(node.leftExtent+1));
+            atts.addAttribute("", "end", String.valueOf(node.rightExtent));
             atts.addAttribute("", "length", String.valueOf(node.rightExtent - node.leftExtent));
             handler.startElement("", gi, gi, atts);
 
@@ -160,7 +281,7 @@ public class XmlForest {
                     final String childgi;
                     if (child.symbol instanceof TerminalSymbol) {
                         atts = newAttributes("value", child.symbol.toString());
-                        atts.addAttribute("ref", "T" + child.id);
+                        atts.addAttribute("ref", "N" + child.id);
                         childgi = "token";
                     } else {
                         atts = newAttributes("name", ((NonterminalSymbol) child.symbol).getName());
@@ -168,6 +289,7 @@ public class XmlForest {
                         childgi = "symbol";
                     }
                     atts.addAttribute("", "start", String.valueOf(child.leftExtent+1));
+                    atts.addAttribute("", "end", String.valueOf(child.rightExtent));
                     atts.addAttribute("", "length", String.valueOf(child.rightExtent - child.leftExtent));
                     handler.startElement("", childgi, childgi, atts);
                     handler.endElement("", childgi, childgi);

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@ org.gradle.parallel=false
 org.gradle.caching=false
 systemProp.org.nineml.logging.defaultLogLevel=info
 
-currentReleaseVersion=3.1.0
-ninemlVersion=3.1.0
+currentReleaseVersion=3.1.1
+ninemlVersion=3.1.1
 
 potTitle=CoffeePot
 potName=coffeepot

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@ org.gradle.parallel=false
 org.gradle.caching=false
 systemProp.org.nineml.logging.defaultLogLevel=info
 
-currentReleaseVersion=3.1.1
-ninemlVersion=3.1.1
+currentReleaseVersion=3.2.0
+ninemlVersion=3.2.0
 
 potTitle=CoffeePot
 potName=coffeepot

--- a/src/website/xml/changelog.xml
+++ b/src/website/xml/changelog.xml
@@ -48,6 +48,12 @@ is returned by the <literal>xml</literal> option).
 <para>Added an <option>--axe</option> option and support for a <literal>random</literal> axe.
 </para>
 </listitem>
+<listitem>
+<para>Added a <option>--trim</option> option to trim leading and trailing whitespace off
+the input. (This can be handy if you have input in a file, your editor automatically adds
+a newline at the end of the file, and your grammar doesn’t support trailing whitespace.)
+</para>
+</listitem>
 </itemizedlist>
 </revdescription>
 </revision>

--- a/src/website/xml/changelog.xml
+++ b/src/website/xml/changelog.xml
@@ -17,16 +17,38 @@ notes for each component.</para>
 the individual component <filename>changelogs.xml</filename> files.</para>
 
 <revhistory>
-<revision xml:id="v311">
-<revnumber>3.1.1</revnumber>
-<date>2023-08-02</date>
+<revision xml:id="v320">
+<revnumber>3.2.0</revnumber>
+<date>2023-08-04</date>
 <revdescription>
-<para audience="coffeesacks">Fixed a bug in the construction of the graph that
+<para audience="coffeegrinder">Reworked how the <classname>Arborist</classname> classes track
+and provide descriptions of how ambiguity was resolved.</para>
+<para audience="coffeefilter"/>
+<itemizedlist audience="coffeesacks">
+<listitem>
+<para>Fixed a bug in the construction of the graph that
 an <classname>XPathAxe</classname> gets to inspect. Nodes were inadvertantly being
 processed many (many!) times in ambiguous forests making the construction very slow.</para>
-<para audience="coffeegrinder"/>
-<para audience="coffeefilter"/>
-<para audience="coffeepot"/>
+</listitem>
+<listitem>
+<para>Changed the <classname>XmlForest</classname> used for resolving ambiguities in the
+<classname>XPathAxe</classname> so that it includes nodes for intermediate states.
+</para>
+</listitem>
+</itemizedlist>
+<itemizedlist audience="coffeepot">
+<listitem>
+<para>The <option>--describe-ambiguity</option> option was broken in
+the previous 3.x releases. It was a fair bit of effort to restore it. The descriptions
+have changed a bit and the <literal>api-xml</literal> option has been removed (the “API” flavor
+is returned by the <literal>xml</literal> option).
+</para>
+</listitem>
+<listitem>
+<para>Added an <option>--axe</option> option and support for a <literal>random</literal> axe.
+</para>
+</listitem>
+</itemizedlist>
 </revdescription>
 </revision>
 <revision xml:id="v310">

--- a/src/website/xml/changelog.xml
+++ b/src/website/xml/changelog.xml
@@ -17,6 +17,18 @@ notes for each component.</para>
 the individual component <filename>changelogs.xml</filename> files.</para>
 
 <revhistory>
+<revision xml:id="v311">
+<revnumber>3.1.1</revnumber>
+<date>2023-08-02</date>
+<revdescription>
+<para audience="coffeesacks">Fixed a bug in the construction of the graph that
+an <classname>XPathAxe</classname> gets to inspect. Nodes were inadvertantly being
+processed many (many!) times in ambiguous forests making the construction very slow.</para>
+<para audience="coffeegrinder"/>
+<para audience="coffeefilter"/>
+<para audience="coffeepot"/>
+</revdescription>
+</revision>
 <revision xml:id="v310">
 <revnumber>3.1.0</revnumber>
 <date>2023-08-01</date>

--- a/website/combined-changelog.xsl
+++ b/website/combined-changelog.xsl
@@ -30,7 +30,7 @@
 <xsl:template match="db:revhistory">
   <xsl:copy>
     <xsl:apply-templates select="@*"/>
-    <xsl:apply-templates select="$revision"/>
+    <xsl:apply-templates select="$changelog/db:revhistory/db:revision"/>
     <xsl:apply-templates/>
   </xsl:copy>
 </xsl:template>


### PR DESCRIPTION
Silly bug caused nodes to be processed many (many!) times when a forest was ambiguous.

Review of this changed caused me to notice that the `--describe-ambiguity` option was broken. That's been fixed as well as some small knock-on changes.