### PR TITLE
Fix bug in prefix parsing when a token wasn’t consumed. Fix #17

### DIFF
--- a/coffeegrinder/src/main/java/org/nineml/coffeegrinder/parser/EarleyParser.java
+++ b/coffeegrinder/src/main/java/org/nineml/coffeegrinder/parser/EarleyParser.java
@@ -402,10 +402,8 @@ public class EarleyParser implements GearleyParser {
                             localRoots.add(item.w);
                         }
                         checkpoint = graph.size();
-                        if (consumedInput) {
-                            restartPos = inputPos+1;
-                            restartable = true;
-                        }
+                        restartable = true;
+                        restartPos = consumedInput ? inputPos + 1 : inputPos;
                     }
                 }
                 if (!localRoots.isEmpty()) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@ org.gradle.parallel=false
 org.gradle.caching=false
 systemProp.org.nineml.logging.defaultLogLevel=info
 
-currentReleaseVersion=3.2.0
-ninemlVersion=3.2.0
+currentReleaseVersion=3.2.1
+ninemlVersion=3.2.1
 
 potTitle=CoffeePot
 potName=coffeepot

--- a/src/website/xml/changelog.xml
+++ b/src/website/xml/changelog.xml
@@ -17,6 +17,18 @@ notes for each component.</para>
 the individual component <filename>changelogs.xml</filename> files.</para>
 
 <revhistory>
+<revision xml:id="v321">
+<revnumber>3.2.1</revnumber>
+<date>2023-08-06</date>
+<revdescription>
+<para audience="coffeegrinder">Fixes
+<link xlink:href="https://github.com/nineml/nineml/issues/17">a bug</link> in
+prefix parsing.</para>
+<para audience="coffeefilter"/>
+<para audience="coffeesacks"/>
+<para audience="coffeepot"/>
+</revdescription>
+</revision>
 <revision xml:id="v320">
 <revnumber>3.2.0</revnumber>
 <date>2023-08-04</date>


### PR DESCRIPTION
The logic for where a prefix parse should restart was not sensitive to the fact that it could be detected whether or not a token was consumed in the most recent iteration.