### PR TITLE
Correct the Maven version range, fix #25

### DIFF
--- a/documentation/src/main/xml/references/changelog.xml
+++ b/documentation/src/main/xml/references/changelog.xml
@@ -16,6 +16,15 @@ N.B.: the log is used automatically in the release notes for each component.
 -->
 
 <revhistory role="changelog">
+<revision xml:id="v323">
+<revnumber>3.2.3</revnumber>
+<date>2023-08-27</date>
+<revdescription>
+<para>Fixes a bug in the Maven POM file (the version range reference was incorrect).
+There are other changes in this release.
+</para>
+</revdescription>
+</revision>
 <revision xml:id="v322">
 <revnumber>3.2.2</revnumber>
 <date>2023-08-26</date>

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@ org.gradle.parallel=false
 org.gradle.caching=false
 systemProp.org.nineml.logging.defaultLogLevel=info
 
-currentReleaseVersion=3.2.2
-ninemlVersion=3.2.2
+currentReleaseVersion=3.2.3
+ninemlVersion=3.2.3
 
 potTitle=CoffeePot
 potName=coffeepot
@@ -23,7 +23,7 @@ xslTNGversion=2.1.9
 xmldocletVersion=0.1.0
 
 // If you change saxonVersions, also update the workflows!
-saxonPomVersionList=[12.3,11.6]
+saxonPomVersionList=[11.0,13.0)
 saxonVersion=12.3
 saxonGroup=net.sf.saxon
 saxonEdition=Saxon-HE


### PR DESCRIPTION
I misunderstood the Maven version range and did it wrong. This PR fixes it so that Maven will accept any version of Saxon in the 11.x or 12.x series. (I'm speculating, slightly, that 12.4+ won't be incompatible in some unexpected way.)