### PR TITLE
Validate VXML grammars

### DIFF
--- a/coffeefilter/build.gradle
+++ b/coffeefilter/build.gradle
@@ -67,9 +67,13 @@ configurations {
 
 dependencies {
   implementation project(':coffeegrinder')
+  implementation (
+    [group: 'org.relaxng', name: 'jing', version: '20220510']
+  )
 
   testImplementation (
     [group: 'com.saxonica', name: 'Saxon-EE', version: saxonVersion],
+    [group: 'org.relaxng', name: 'jing', version: '20220510'],
     files(saxonLicenseDir)
   )
   testsuite (
@@ -322,6 +326,42 @@ tasks.withType(JavaCompile) {
 
 // ============================================================
 
+def pomXml() {
+  // Make the jing dependency optional
+
+  return {
+    Node pom = asNode()
+    NodeList pomNodes = pom.value()
+    Node dependencies = null
+    pomNodes.forEach { pomit ->
+      if (pomit.name().getNamespaceURI() == 'http://maven.apache.org/POM/4.0.0'
+          && pomit.name().getLocalPart() == 'dependencies') {
+        dependencies = pomit;
+      }
+    }
+
+    Iterator iterator = dependencies.iterator()
+    while (iterator.hasNext()) {
+      Node dep = iterator.next()
+      NodeList str = dep.get("artifactId")
+      if ("jing".equals(str.get(0).value().get(0))) {
+        def optional = dep.optional[0]
+        if (!optional) {
+          optional = dep.appendNode("optional")
+        }
+        optional.value = 'true'
+      }
+    }
+/*
+    def dependencyNode = dependencies.appendNode('dependency')
+    dependencyNode.appendNode('groupId', 'net.sf.saxon')
+    dependencyNode.appendNode('artifactId', 'Saxon-HE')
+    dependencyNode.appendNode('version', saxonPomVersionList)
+    dependencyNode.appendNode('scope', 'runtime')
+*/
+  }
+}
+
 signing {
   sign publishing.publications
 }
@@ -355,6 +395,8 @@ publishing {
             name = 'Norman Walsh'
           }
         }
+
+        withXml pomXml()
       }
 
       groupId = "org.nineml"

--- a/coffeefilter/src/main/java/org/nineml/coffeefilter/ParserOptions.java
+++ b/coffeefilter/src/main/java/org/nineml/coffeefilter/ParserOptions.java
@@ -35,6 +35,7 @@ public class ParserOptions extends org.nineml.coffeegrinder.parser.ParserOptions
     private boolean strictAmbiguity = false;
     private String startSymbol = null;
     private final HashSet<String> disabledPragmas;
+    private boolean validateVxml = true;
 
     // FIXME: this list should somehow be connected to the pragmas defined in InvisibleXml
     private static final HashSet<String> knownPragmas = new HashSet<>(Arrays.asList("discard-empty", "ns", "priority", "regex", "rename"));
@@ -87,6 +88,7 @@ public class ParserOptions extends org.nineml.coffeegrinder.parser.ParserOptions
         ignoreBOM = copy.ignoreBOM;
         disabledPragmas = new HashSet<>(copy.disabledPragmas);
         startSymbol = copy.startSymbol;
+        validateVxml = copy.validateVxml;
     }
 
     /**
@@ -492,4 +494,19 @@ public class ParserOptions extends org.nineml.coffeegrinder.parser.ParserOptions
         startSymbol = name;
     }
 
+    /**
+     * Should validate VXML grammars?
+     * @return true if the grammar should be validated
+     */
+    public boolean getValidateVxml() {
+        return validateVxml;
+    }
+
+    /**
+     * Set the {@link #getValidateVxml()} property.
+     * @param validate true if VXML grammars should be validated
+     */
+    public void setValidateVxml(boolean validate) {
+        validateVxml = validate;
+    }
 }

--- a/coffeefilter/src/main/java/org/nineml/coffeefilter/exceptions/IxmlException.java
+++ b/coffeefilter/src/main/java/org/nineml/coffeefilter/exceptions/IxmlException.java
@@ -98,6 +98,7 @@ public class IxmlException extends RuntimeException {
     public static IxmlException renameUnavailable(String name, String rename) { return getException("E015", new String[] {name, rename}); }
     public static IxmlException repeatedPragma(String name, String data1, String data2) { return getException("E016", new String[] {name, data1, data2}); }
     public static IxmlException noSuchSymbol(String name) { return getException("E017", name); }
+    public static IxmlException invalidVxmlGrammar(String schema, String message) { return getException("E018", new String[] {schema, message}); }
 
     private static String symbolList(Set<NonterminalSymbol> symbols) {
         StringBuilder sb = new StringBuilder();

--- a/coffeefilter/src/main/java/org/nineml/coffeefilter/util/VxmlValidator.java
+++ b/coffeefilter/src/main/java/org/nineml/coffeefilter/util/VxmlValidator.java
@@ -1,0 +1,104 @@
+package org.nineml.coffeefilter.util;
+
+import com.thaiopensource.util.PropertyMapBuilder;
+import com.thaiopensource.validate.SchemaReader;
+import com.thaiopensource.validate.ValidateProperty;
+import com.thaiopensource.validate.ValidationDriver;
+import com.thaiopensource.validate.prop.rng.RngProperty;
+import com.thaiopensource.validate.rng.CompactSchemaReader;
+import org.nineml.coffeefilter.ParserOptions;
+import org.nineml.coffeefilter.exceptions.IxmlException;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+
+import java.io.*;
+import java.net.URL;
+
+public class VxmlValidator {
+    private String error = null;
+
+    public boolean valid() {
+        return error == null;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public InputStream validateVxml(InputStream stream, URL schema, ParserOptions options) throws IOException {
+        // This is kind of ugly. I want to read the stream in order to validate it, but
+        // I have to return a stream in order to parse it. So we buffer it. *shrug*
+        //
+        // Also: don't throw an exception in here because it comes across as an
+        // invocation exception.
+        
+        StringBuilder sb = new StringBuilder();
+        BufferedReader reader = new BufferedReader(new InputStreamReader(stream));
+        String line = reader.readLine();
+        while (line != null) {
+            sb.append(line).append("\n");
+            line = reader.readLine();
+        }
+
+        ByteArrayInputStream bais = new ByteArrayInputStream(sb.toString().getBytes());
+
+        RelaxNgErrorHandler errorHandler = new RelaxNgErrorHandler();
+        try {
+            PropertyMapBuilder properties = new PropertyMapBuilder();
+            properties.put(ValidateProperty.ERROR_HANDLER, errorHandler);
+            RngProperty.CHECK_ID_IDREF.add(properties);
+            properties.put(RngProperty.CHECK_ID_IDREF, null);
+            RngProperty.FEASIBLE.add(properties);
+
+            SchemaReader sr = CompactSchemaReader.getInstance();
+
+            ValidationDriver driver = new ValidationDriver(properties.toPropertyMap(), properties.toPropertyMap(), sr);
+            InputSource insrc = ValidationDriver.uriOrFileInputSource(schema.toString());
+
+            if (driver.loadSchema(insrc)) {
+                insrc = new InputSource(bais);
+                if (!driver.validate(insrc)) {
+                    error = errorHandler.error;
+                }
+            } else {
+                options.getLogger().warn("InvisibleXmlRng", "Failed to load RELAX NG schema for VXML");
+            }
+        } catch (IOException | SAXException ex) {
+            // If it wasn't XML, it was never going to succeed
+            if (errorHandler.xml) {
+                error = errorHandler.error;
+            }
+        }
+
+        return new ByteArrayInputStream(sb.toString().getBytes());
+    }
+
+    private static class RelaxNgErrorHandler implements ErrorHandler {
+        public boolean xml = true;
+        public String error = null;
+
+        @Override
+        public void warning(SAXParseException exception) throws SAXException {
+            // nop
+        }
+
+        @Override
+        public void error(SAXParseException exception) throws SAXException {
+            if (error == null) {
+                error = exception.getMessage();
+            }
+        }
+
+        @Override
+        public void fatalError(SAXParseException exception) throws SAXException {
+            if (exception.getMessage().contains("Content is not allowed in prolog")) {
+                xml = false;
+            }
+            if (error == null) {
+                error = exception.getMessage();
+            }
+        }
+    }
+}

--- a/coffeefilter/src/main/resources/org/nineml/coffeefilter/en_messages.txt
+++ b/coffeefilter/src/main/resources/org/nineml/coffeefilter/en_messages.txt
@@ -10,9 +10,10 @@ DT02: Duplicate names forbidden: %2.
 E006: Invalid tmark: %1.
 E012: Unreachable symbol(s): ‘%1’.
 E013: Unproductive symbol(s): ‘%1’.
-E015: Symbol renaming is not supported in 1.0 grammars %1 > %2.
+E015: Symbol renaming is not supported in 1.0 grammars: %1 > %2.
 E016: Pragma cannot be repeated: %1 (%2, %3).
 E017: The start symbol specified does not appear in the grammar: %1.
+E018: Invalid schema: %1 (%2).
 I001: Internal error: failed to load ixml specification grammar: %1.
 I002: Internal error: failed to load ixml specification grammar: %1.
 I003: Internal error: %1.

--- a/coffeefilter/src/main/resources/org/nineml/coffeefilter/ixml.rnc
+++ b/coffeefilter/src/main/resources/org/nineml/coffeefilter/ixml.rnc
@@ -1,0 +1,188 @@
+namespace ixml = "http://invisiblexml.org/NS"
+
+start = ixml
+
+hex       = xsd:string { pattern = "[0-9a-fA-F]+" }
+rangechar = xsd:string { pattern = "." }
+rangehex  = xsd:string { pattern = "#[0-9a-fA-F]+" }
+charclass = xsd:string { pattern = "[A-Z][A-Za-z]?" }
+name      = xsd:NCName
+
+s = comment*
+sp = (comment|pragma)*
+
+comment =
+    element comment {
+        (text|comment)*
+    }
+
+ixml =
+    element ixml {
+        attribute ixml:state { text }?,
+        s,
+        prolog?,
+        (rule|s)+
+    }
+
+prolog =
+    element prolog {
+        version?,
+        s,
+        ppragma*,
+        s
+    }
+
+version =
+    element version {
+        attribute \string { text },
+        empty
+    }
+
+rule =
+    element rule {
+        attribute mark { "^" | "@" | "-" }?,
+        attribute name { name },
+        attribute rename { name }?,
+        sp,
+        alt+,
+        sp
+    }
+
+alts =
+    element alts {
+        alt+,
+        s
+    }
+
+alt =
+    element alt {
+        (literal | inclusion | exclusion
+         | nonterminal
+         | insertion
+         | option
+         | repeat0
+         | repeat1
+         | alts
+         | s)*
+    }
+
+literal =
+    element literal {
+        attribute tmark { "^" | "-" }?,
+        (
+            attribute hex { hex }
+          | attribute \string { text }
+        ),
+        sp
+    }
+
+inclusion =
+    element inclusion {
+        attribute tmark { "^" | "-" }?,
+        s,
+        member*,
+        s
+    }
+
+exclusion =
+    element exclusion {
+        attribute tmark { "^" | "-" }?,
+        s,
+        member*,
+        s
+    }
+
+member =
+    element member {
+        (
+            attribute \string { text }
+          | attribute hex { hex }
+          | attribute code { charclass }
+          | (attribute from { rangechar | rangehex }
+             & attribute to { rangechar | rangehex })
+        ),
+        s
+    }
+
+nonterminal =
+    element nonterminal {
+        attribute mark { "^" | "@" | "-" }?,
+        attribute name { name },
+        attribute rename { name }?,
+        sp
+    }
+
+insertion =
+    element insertion {
+        (
+            attribute \string { text }
+          | attribute hex { hex }
+        ),
+        s
+    }
+
+option =
+    element option {
+        (literal | inclusion | exclusion
+         | nonterminal
+         | insertion
+         | option
+         | repeat0
+         | repeat1
+         | alts),
+        s
+    }
+
+repeat0 =
+    element repeat0 {
+        (literal | inclusion | exclusion
+         | nonterminal
+         | insertion
+         | option
+         | repeat0
+         | repeat1
+         | alts),
+        s,
+        sep?
+    }
+
+repeat1 =
+    element repeat1 {
+        (literal | inclusion | exclusion
+         | nonterminal
+         | insertion
+         | option
+         | repeat0
+         | repeat1
+         | alts),
+        s,
+        sep?
+    }
+
+sep =
+    element sep {
+        (literal | inclusion | exclusion
+         | nonterminal
+         | insertion
+         | option
+         | repeat0
+         | repeat1
+         | alts)
+    }        
+        
+ppragma =
+    element ppragma {
+        attribute pname { name },
+        pragma-data?
+    }
+
+pragma =
+    element pragma {
+        attribute pname { name },
+        pragma-data?
+}
+
+pragma-data =
+    element pragma-data {
+        text 
+    }

--- a/coffeefilter/src/main/resources/org/nineml/coffeefilter/ixml.rnc
+++ b/coffeefilter/src/main/resources/org/nineml/coffeefilter/ixml.rnc
@@ -2,11 +2,18 @@ namespace ixml = "http://invisiblexml.org/NS"
 
 start = ixml
 
-hex       = xsd:string { pattern = "[0-9a-fA-F]+" }
-rangechar = xsd:string { pattern = "." }
-rangehex  = xsd:string { pattern = "#[0-9a-fA-F]+" }
-charclass = xsd:string { pattern = "[A-Z][A-Za-z]?" }
-name      = xsd:NCName
+# On the one hand, it's tempting to make patterns for these values
+# that enforce their constraints. On the other hand, doing so causes
+# at least one test suite test to fail because the schema validation
+# fails before the test is even run. This produces a different, and
+# non-standard, error code. To avoid that, no patterns are used. The
+# processor will check them and raise appropriate errors anyway.
+
+hex       = text
+rangechar = text
+rangehex  = text
+charclass = text
+name      = text
 
 s = comment*
 sp = (comment|pragma)*

--- a/coffeefilter/src/main/resources/org/nineml/coffeefilter/pragmas2.ixml
+++ b/coffeefilter/src/main/resources/org/nineml/coffeefilter/pragmas2.ixml
@@ -1,4 +1,4 @@
-ixml version "1.0".
+ixml version "1.1-nineml".
 { Based on the 2022-06-07 grammar }
 
          ixml: s, prolog?, rule++RS, s. 
@@ -9,10 +9,12 @@ ixml version "1.0".
          -tab: -#9.
           -lf: -#a.
           -cr: -#d.
-      comment: -"{", ((comment; ~["[]{}"]), (cchar; comment)*)?, -"}".
+      comment: -"{", ((comment-or-pragma; ~["[]{}"]), (cchar; comment-or-pragma)*)?, -"}".
+comment-or-pragma>comment: -"{", (cchar; comment-or-pragma)*, -"}".
+
        -cchar: ~["{}"].
 
-       prolog: ((version, ppragma**s) | ppragma++s), s. 
+       prolog: (version | (version, s, ppragma++s) | ppragma++s), s.
       version: -"ixml", RS, -"version", RS, string, s, -'.' .
 
          rule: annotation, naming, -["=:"], s, -alts, (pragma, sp)?, -".". 

--- a/coffeefilter/src/main/resources/org/nineml/coffeefilter/pragmas2.xml
+++ b/coffeefilter/src/main/resources/org/nineml/coffeefilter/pragmas2.xml
@@ -1,6 +1,6 @@
 <ixml>
    <prolog>
-      <version string='1.0'/>
+      <version string='1.1-nineml'/>
       <comment> Based on the 2022-06-07 grammar </comment>
    </prolog>
    <rule name='ixml'>
@@ -87,7 +87,7 @@
                <alt>
                   <alts>
                      <alt>
-                        <nonterminal name='comment'/>
+                        <nonterminal name='comment-or-pragma'/>
                      </alt>
                      <alt>
                         <exclusion>
@@ -101,13 +101,29 @@
                            <nonterminal name='cchar'/>
                         </alt>
                         <alt>
-                           <nonterminal name='comment'/>
+                           <nonterminal name='comment-or-pragma'/>
                         </alt>
                      </alts>
                   </repeat0>
                </alt>
             </alts>
          </option>
+         <literal tmark='-' string='}'/>
+      </alt>
+   </rule>
+   <rule name='comment-or-pragma' rename='comment'>
+      <alt>
+         <literal tmark='-' string='{'/>
+         <repeat0>
+            <alts>
+               <alt>
+                  <nonterminal name='cchar'/>
+               </alt>
+               <alt>
+                  <nonterminal name='comment-or-pragma'/>
+               </alt>
+            </alts>
+         </repeat0>
          <literal tmark='-' string='}'/>
       </alt>
    </rule>
@@ -122,15 +138,19 @@
       <alt>
          <alts>
             <alt>
+               <nonterminal name='version'/>
+            </alt>
+            <alt>
                <alts>
                   <alt>
                      <nonterminal name='version'/>
-                     <repeat0>
+                     <nonterminal name='s'/>
+                     <repeat1>
                         <nonterminal name='ppragma'/>
                         <sep>
                            <nonterminal name='s'/>
                         </sep>
-                     </repeat0>
+                     </repeat1>
                   </alt>
                </alts>
             </alt>

--- a/coffeefilter/src/test/java/org/nineml/coffeefilter/VxmlValidatorTest.java
+++ b/coffeefilter/src/test/java/org/nineml/coffeefilter/VxmlValidatorTest.java
@@ -1,0 +1,61 @@
+package org.nineml.coffeefilter;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.nineml.coffeefilter.exceptions.IxmlException;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class VxmlValidatorTest {
+    @Test
+    public void validVxml() {
+        ParserOptions options = new ParserOptions();
+        InvisibleXml ixml = new InvisibleXml(options);
+
+        try {
+            InvisibleXmlParser parser = ixml.getParser(new File("src/test/resources/numbers.xml"));
+            InvisibleXmlDocument document = parser.parse("3.14");
+            String xml = document.getTree();
+            Assertions.assertEquals("<number><float><digits>3</digits><point/><digits>14</digits></float></number>", xml);
+        } catch (IOException err) {
+            fail();
+        }
+    }
+
+    @Test
+    public void invalidVxml() {
+        ParserOptions options = new ParserOptions();
+        options.setValidateVxml(true);
+        InvisibleXml ixml = new InvisibleXml(options);
+
+        try {
+            InvisibleXmlParser parser = ixml.getParser(new File("src/test/resources/numbers-invalid.xml"));
+            fail();
+        } catch (IxmlException ex) {
+            Assertions.assertEquals("E018", ex.getCode());
+        } catch (IOException ex) {
+            fail();
+        }
+    }
+
+    @Test
+    public void uncheckedVxml() {
+        ParserOptions options = new ParserOptions();
+        options.setValidateVxml(false);
+        InvisibleXml ixml = new InvisibleXml(options);
+
+        try {
+            InvisibleXmlParser parser = ixml.getParser(new File("src/test/resources/numbers-invalid.xml"));
+            InvisibleXmlDocument document = parser.parse("3.14");
+            String xml = document.getTree();
+            Assertions.assertEquals("<number><float><digits>3</digits><point/><digits>14</digits></float></number>", xml);
+        } catch (IOException err) {
+            fail();
+        }
+    }
+
+
+}

--- a/coffeefilter/src/test/resources/numbers-invalid.xml
+++ b/coffeefilter/src/test/resources/numbers-invalid.xml
@@ -1,0 +1,82 @@
+<!-- This would be valid if extension attributes were allowed. -->
+<ixml xmlns:example="https://example.com/" example:bad-attribute="true">
+   <rule name='number'>
+      <alt>
+         <nonterminal name='integer'/>
+      </alt>
+      <alt>
+         <nonterminal name='float'/>
+      </alt>
+      <alt>
+         <nonterminal name='scientific'/>
+      </alt>
+   </rule>
+   <rule name='sign'>
+      <alt>
+         <literal string='+'/>
+      </alt>
+      <alt>
+         <literal string='-'/>
+      </alt>
+   </rule>
+   <rule mark='-' name='digit'>
+      <alt>
+         <inclusion>
+            <member from='0' to='9'/>
+         </inclusion>
+      </alt>
+   </rule>
+   <rule name='digits'>
+      <alt>
+         <repeat1>
+            <nonterminal name='digit'/>
+         </repeat1>
+      </alt>
+   </rule>
+   <rule name='integer'>
+      <alt>
+         <option>
+            <nonterminal name='sign'/>
+         </option>
+         <nonterminal name='digits'/>
+      </alt>
+   </rule>
+   <rule name='point'>
+      <alt>
+         <literal tmark='-' string='.'/>
+      </alt>
+   </rule>
+   <rule name='float'>
+      <alt>
+         <option>
+            <nonterminal name='sign'/>
+         </option>
+         <nonterminal name='digits'/>
+         <nonterminal name='point'/>
+         <nonterminal name='digits'/>
+      </alt>
+   </rule>
+   <rule name='E'>
+      <alt>
+         <literal tmark='-' string='E'/>
+      </alt>
+   </rule>
+   <rule name='scientific'>
+      <alt>
+         <nonterminal name='integer'/>
+         <nonterminal name='E'/>
+         <option>
+            <nonterminal name='sign'/>
+         </option>
+         <nonterminal name='digits'/>
+      </alt>
+      <alt>
+         <nonterminal name='float'/>
+         <nonterminal name='E'/>
+         <option>
+            <nonterminal name='sign'/>
+         </option>
+         <nonterminal name='digits'/>
+      </alt>
+   </rule>
+</ixml>

--- a/coffeefilter/src/test/resources/numbers.xml
+++ b/coffeefilter/src/test/resources/numbers.xml
@@ -1,0 +1,81 @@
+<ixml>
+   <rule name='number'>
+      <alt>
+         <nonterminal name='integer'/>
+      </alt>
+      <alt>
+         <nonterminal name='float'/>
+      </alt>
+      <alt>
+         <nonterminal name='scientific'/>
+      </alt>
+   </rule>
+   <rule name='sign'>
+      <alt>
+         <literal string='+'/>
+      </alt>
+      <alt>
+         <literal string='-'/>
+      </alt>
+   </rule>
+   <rule mark='-' name='digit'>
+      <alt>
+         <inclusion>
+            <member from='0' to='9'/>
+         </inclusion>
+      </alt>
+   </rule>
+   <rule name='digits'>
+      <alt>
+         <repeat1>
+            <nonterminal name='digit'/>
+         </repeat1>
+      </alt>
+   </rule>
+   <rule name='integer'>
+      <alt>
+         <option>
+            <nonterminal name='sign'/>
+         </option>
+         <nonterminal name='digits'/>
+      </alt>
+   </rule>
+   <rule name='point'>
+      <alt>
+         <literal tmark='-' string='.'/>
+      </alt>
+   </rule>
+   <rule name='float'>
+      <alt>
+         <option>
+            <nonterminal name='sign'/>
+         </option>
+         <nonterminal name='digits'/>
+         <nonterminal name='point'/>
+         <nonterminal name='digits'/>
+      </alt>
+   </rule>
+   <rule name='E'>
+      <alt>
+         <literal tmark='-' string='E'/>
+      </alt>
+   </rule>
+   <rule name='scientific'>
+      <alt>
+         <nonterminal name='integer'/>
+         <nonterminal name='E'/>
+         <option>
+            <nonterminal name='sign'/>
+         </option>
+         <nonterminal name='digits'/>
+      </alt>
+      <alt>
+         <nonterminal name='float'/>
+         <nonterminal name='E'/>
+         <option>
+            <nonterminal name='sign'/>
+         </option>
+         <nonterminal name='digits'/>
+      </alt>
+   </rule>
+</ixml>

--- a/coffeepot/examples/bibtex.ixml
+++ b/coffeepot/examples/bibtex.ixml
@@ -1,4 +1,4 @@
-bibtex: item+itemsep, s* .
+bibtex: item++itemsep, s* .
 itemsep: s+ .
 
 -item: comment ; entry .
@@ -10,7 +10,7 @@ entry: -"@", @type, s*, -'{', s*, @citekey, fields?, s*, -'}' .
 type: -name .
 citekey: -name .
 
--fields: -',', field+fsep .
+-fields: -',', field++fsep .
 
 field: s*, name, s*, -'=', s*, value .
 value: quotedvalue; bracedvalue; atomicvalue .

--- a/coffeepot/src/main/java/org/nineml/coffeepot/utils/ParserOptions.java
+++ b/coffeepot/src/main/java/org/nineml/coffeepot/utils/ParserOptions.java
@@ -131,7 +131,7 @@ public class ParserOptions extends org.nineml.coffeefilter.ParserOptions {
     }
 
     /**
-     * Set the {@link #getPedantic()} property.
+     * Set the {@link #getProvenance()} property.
      * @param outputProvenance true if a provenance comment should be generated.
      */
     public void setProvenance(boolean outputProvenance) {
@@ -200,6 +200,7 @@ public class ParserOptions extends org.nineml.coffeefilter.ParserOptions {
         show(stderr, logger, "Trailing newline on output: %s", getTrailingNewlineOnOutput());
         show(stderr, logger, "Priority style: %s", getPriorityStyle());
         show(stderr, logger, "Provenance: %s", getProvenance());
+        show(stderr, logger, "Validate VXML: %s", getValidateVxml());
 
         if (getGraphOptions().isEmpty()) {
             show(stderr, logger, "Graph options: null");

--- a/coffeepot/src/main/java/org/nineml/coffeepot/utils/ParserOptionsLoader.java
+++ b/coffeepot/src/main/java/org/nineml/coffeepot/utils/ParserOptionsLoader.java
@@ -50,6 +50,7 @@ public class ParserOptionsLoader {
         PROPERTY_NAMES.add("normalize-line-endings");
         PROPERTY_NAMES.add("mark-ambiguities");
         PROPERTY_NAMES.add("provenance");
+        PROPERTY_NAMES.add("validate-vxml");
     }
 
     private static final String propfn = "nineml.properties";
@@ -148,7 +149,7 @@ public class ParserOptionsLoader {
 
         options.setPrettyPrint(getBooleanProperty("pretty-print"));
         options.setIgnoreTrailingWhitespace(getBooleanProperty("ignore-trailing-whitespace"));
-        options.setIgnoreBOM(getBooleanProperty("ignore-bom"));
+        options.setIgnoreBOM(getBooleanProperty("ignore-bom", true));
         options.setTrailingNewlineOnOutput(getBooleanProperty("trailing-newline-on-output", true));
         options.setAsciiOnly(getBooleanProperty("ascii-only", false));
         options.setStrictAmbiguity(getBooleanProperty("strict-ambiguity", false));
@@ -159,10 +160,11 @@ public class ParserOptionsLoader {
         options.setNormalizeLineEndings(getBooleanProperty("normalize-line-endings"));
         options.setMarkAmbiguities(getBooleanProperty("mark-ambiguities"));
         options.setProvenance(getBooleanProperty("provenance"));
+        options.setValidateVxml(getBooleanProperty("validate-vxml", true));
 
         options.setAllowMultipleDefinitions(getBooleanProperty("allow-multiple-definitions"));
-        options.setAllowUnproductiveSymbols(getBooleanProperty("allow-unproductive-symbols"));
-        options.setAllowUnreachableSymbols(getBooleanProperty("allow-unreachable-symbols"));
+        options.setAllowUnproductiveSymbols(getBooleanProperty("allow-unproductive-symbols", true));
+        options.setAllowUnreachableSymbols(getBooleanProperty("allow-unreachable-symbols", true));
         options.setAllowUndefinedSymbols(getBooleanProperty("allow-undefined-symbols"));
 
         String value = getProperty("default-log-level", null);
@@ -190,7 +192,7 @@ public class ParserOptionsLoader {
         value = getProperty("suppress-states", null);
         if (value != null) {
             for (String state : value.split(",")) {
-                if (!"".equals(state.trim())) {
+                if (!state.trim().isEmpty()) {
                     options.suppressState(state.trim());
                 }
             }
@@ -199,7 +201,7 @@ public class ParserOptionsLoader {
         value = getProperty("disable-pragmas", null);
         if (value != null) {
             for (String pragma : value.split(",")) {
-                if (!"".equals(pragma.trim())) {
+                if (!pragma.trim().isEmpty()) {
                     options.disablePragma(pragma.trim());
                 }
             }
@@ -208,7 +210,7 @@ public class ParserOptionsLoader {
         value = getProperty("enable-pragmas", null);
         if (value != null) {
             for (String pragma : value.split(",")) {
-                if (!"".equals(pragma.trim())) {
+                if (!pragma.trim().isEmpty()) {
                     options.enablePragma(pragma.trim());
                 }
             }

--- a/documentation/src/main/xml/coffeepot/examples/contacts.ixml
+++ b/documentation/src/main/xml/coffeepot/examples/contacts.ixml
@@ -1,4 +1,4 @@
-{[nineml csv-columns email,name]} .
+{[+nineml csv-columns email,name]}
 
 contacts: (contact, NL*)+ .
 contact: name, NL, (email, NL)?, (phone, NL)? .


### PR DESCRIPTION
This PR mostly adds a new optional feature, the ability to validate VXML (i.e., iXML schemas in XML format rather than text format) against a RELAX NG grammar before using them. This can catch more errors. Also, this will fix #14 .

If the Jing libraries aren't on the classpath, no errors are raised, but also nothing is validated.

There are also a few smaller tweaks in here, including some fixes to the pragmas grammar.