### PR TITLE
Restore the CSV-related pragmas

### DIFF
--- a/coffeefilter/src/main/java/org/nineml/coffeefilter/InvisibleXml.java
+++ b/coffeefilter/src/main/java/org/nineml/coffeefilter/InvisibleXml.java
@@ -49,6 +49,7 @@ public class InvisibleXml {
     public static final String INSERTION_ATTRIBUTE = "https://coffeefilter.nineml.org/attr/insertion";
     /** The internal name for the discard parser attribute. */
     public static final String DISCARD_ATTRIBUTE = "https://coffeefilter.nineml.org/attr/discard";
+    public static final String CSV_HEADING_ATTRIBUTE = "https://coffeefilter.nineml.org/attr/csv-heading";
 
     /** The namespace prefix for the Invisilble XML namespace. */
     public static final String ixml_prefix = "ixml";

--- a/coffeefilter/src/main/java/org/nineml/coffeefilter/InvisibleXmlParser.java
+++ b/coffeefilter/src/main/java/org/nineml/coffeefilter/InvisibleXmlParser.java
@@ -107,6 +107,14 @@ public class InvisibleXmlParser {
     }
 
     /**
+     * Get the pragmas associated with this parser.
+     * @return the list of pragmas.
+     */
+    public List<IPragma> getPragmas() {
+        return ixml.getPragmas();
+    }
+
+    /**
      * Return the exception that caused an attempt to build a parser to fail.
      * <p>If the attempt was successful, or if failure did not raise an exception, <code>null</code>
      * will be returned.</p>

--- a/coffeefilter/src/main/java/org/nineml/coffeefilter/model/IPragma.java
+++ b/coffeefilter/src/main/java/org/nineml/coffeefilter/model/IPragma.java
@@ -5,7 +5,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class IPragma extends XNonterminal {
-    public enum PragmaType { UNDEFINED, DISCARD_EMPTY, METADATA, PRIORITY, REGEX, RENAME, XMLNS, /* CSV_HEADING, */ STRICT };
+    public enum PragmaType { UNDEFINED, DISCARD_EMPTY, METADATA, PRIORITY, REGEX, RENAME, XMLNS, CSV_HEADING, CSV_COLUMNS, STRICT };
     public static final Map<PragmaType, String> pragmaTypeNames;
     static {
         HashMap<PragmaType, String> names = new HashMap<>();
@@ -16,7 +16,8 @@ public class IPragma extends XNonterminal {
         names.put(PragmaType.REGEX, "regex");
         names.put(PragmaType.RENAME, "rename");
         names.put(PragmaType.XMLNS, "xmlns");
-        //names.put(PragmaType.CSV_HEADING, "csv heading");
+        names.put(PragmaType.CSV_HEADING, "csv-heading");
+        names.put(PragmaType.CSV_COLUMNS, "csv-columns");
         names.put(PragmaType.STRICT, "strict");
         pragmaTypeNames = Collections.unmodifiableMap(names);
     }

--- a/coffeefilter/src/main/java/org/nineml/coffeefilter/model/IPragmaCsvColumns.java
+++ b/coffeefilter/src/main/java/org/nineml/coffeefilter/model/IPragmaCsvColumns.java
@@ -1,0 +1,23 @@
+package org.nineml.coffeefilter.model;
+
+import java.util.*;
+
+public class IPragmaCsvColumns extends IPragma {
+    public final List<String> columns;
+
+    public IPragmaCsvColumns(XNode parent, String name, String data) {
+        super(parent, name);
+        ptype = PragmaType.CSV_COLUMNS;
+        inherit = false;
+
+        ArrayList<String> colnames = new ArrayList<>();
+        if (data != null) {
+            colnames.addAll(Arrays.asList(data.split(",\\s*")));
+        }
+        columns = colnames;
+
+        if (columns.isEmpty()) {
+            parent.getRoot().getOptions().getLogger().error(XNode.logcategory, "No columns specified for csv-columns");
+        }
+    }
+}

--- a/coffeefilter/src/main/java/org/nineml/coffeefilter/model/IPragmaCsvHeading.java
+++ b/coffeefilter/src/main/java/org/nineml/coffeefilter/model/IPragmaCsvHeading.java
@@ -1,0 +1,29 @@
+package org.nineml.coffeefilter.model;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class IPragmaCsvHeading extends IPragma {
+    public final String heading;
+
+    public IPragmaCsvHeading(XNode parent, String name, String data) {
+        super(parent, name);
+        ptype = PragmaType.CSV_HEADING;
+        inherit = false;
+
+        if (data == null) {
+            heading = null;
+            parent.getRoot().getOptions().getLogger().error(XNode.logcategory, "No heading specified for csv-heading");
+        } else {
+            data = data.trim();
+            if ((data.startsWith("\"") && data.endsWith("\"")
+                    || (data.startsWith("'") && data.endsWith("'")))) {
+                heading = data.substring(1, data.length()-1);
+            } else {
+                heading = null;
+                parent.getRoot().getOptions().getLogger().error(XNode.logcategory, "Failed to parse csv-heading: %s", data);
+            }
+        }
+    }
+}

--- a/coffeefilter/src/main/java/org/nineml/coffeefilter/model/Ixml.java
+++ b/coffeefilter/src/main/java/org/nineml/coffeefilter/model/Ixml.java
@@ -376,9 +376,13 @@ public class Ixml extends XNonterminal {
                 for (IPragma pragma : rule.pragmas) {
                     if (pragma instanceof IPragmaRegex) {
                         regex = pragma.getPragmaData();
-                        //attributes.add(new ParserAttribute(ParserAttribute.REGEX_NAME, pragma.getPragmaData()));
                     } else if (pragma instanceof IPragmaPriority) {
                         attributes.add(new ParserAttribute(ForestNode.PRIORITY_ATTRIBUTE, pragma.getPragmaData()));
+                    } else if (pragma instanceof IPragmaCsvHeading) {
+                        String heading = ((IPragmaCsvHeading) pragma).heading;
+                        if (heading != null) {
+                            attributes.add(new ParserAttribute(InvisibleXml.CSV_HEADING_ATTRIBUTE, heading));
+                        }
                     } else {
                         options.getLogger().debug(logcategory, "Unknown pragma, or does not apply to rule: %s", pragma);
                     }

--- a/coffeefilter/src/main/java/org/nineml/coffeefilter/model/XNode.java
+++ b/coffeefilter/src/main/java/org/nineml/coffeefilter/model/XNode.java
@@ -424,6 +424,10 @@ public abstract class XNode {
                 break;
             case "priority":
                 return new IPragmaPriority(pragma.parent, pragma.name, data);
+            case "csv-columns":
+                return new IPragmaCsvColumns(pragma.parent, pragma.name, data);
+            case "csv-heading":
+                return new IPragmaCsvHeading(pragma.parent, pragma.name, data);
             default:
                 break;
         }

--- a/coffeepot/src/main/java/org/nineml/coffeepot/managers/OutputManager.java
+++ b/coffeepot/src/main/java/org/nineml/coffeepot/managers/OutputManager.java
@@ -4,11 +4,11 @@ import net.sf.saxon.s9api.*;
 import org.nineml.coffeefilter.InvisibleXml;
 import org.nineml.coffeefilter.InvisibleXmlDocument;
 import org.nineml.coffeefilter.InvisibleXmlParser;
+import org.nineml.coffeefilter.model.IPragma;
+import org.nineml.coffeefilter.model.IPragmaCsvColumns;
 import org.nineml.coffeefilter.trees.*;
 import org.nineml.coffeefilter.trees.StringTreeBuilder;
-import org.nineml.coffeegrinder.parser.Family;
-import org.nineml.coffeegrinder.parser.ForestNode;
-import org.nineml.coffeegrinder.parser.Symbol;
+import org.nineml.coffeegrinder.parser.*;
 import org.nineml.coffeegrinder.trees.*;
 import org.nineml.coffeepot.BuildConfig;
 import org.nineml.coffeepot.trees.VerboseAxe;
@@ -291,6 +291,7 @@ public class OutputManager {
                     walker.getTree(doc.getAdapter(dataBuilder));
                     dataTree = dataBuilder.getTree();
                     List<CsvColumn> columns = dataTree.prepareCsv();
+
                     if (columns == null) {
                         walker.reset();
                         StringTreeBuilder shandler = new StringTreeBuilder(opts, out);
@@ -303,6 +304,50 @@ public class OutputManager {
                         }
                         return;
                     }
+
+                    // Are the csv-columns defined in the grammar?
+                    List<String> colnames = null;
+                    for (IPragma pragma : parser.getPragmas()) {
+                        if (pragma instanceof IPragmaCsvColumns) {
+                            colnames = ((IPragmaCsvColumns) pragma).columns;
+                        }
+                    }
+
+                    if (colnames != null) {
+                        List<CsvColumn> updatedColumns = new ArrayList<>();
+                        for (String name : colnames) {
+                            boolean found = false;
+                            for (CsvColumn column : columns) {
+                                if (column.getName().equals(name)) {
+                                    updatedColumns.add(column);
+                                    found = true;
+                                }
+                            }
+                            if (!found) {
+                                config.stderr.printf("No column named %s in data%n", name);
+                            }
+                        }
+                        if (updatedColumns.isEmpty()) {
+                            config.stderr.println("No columns selected");
+                            returnCode = 1;
+                            return;
+                        }
+                        columns = updatedColumns;
+                    }
+
+                    // Are there headers defined for the columns being output?
+                    Grammar grammar = parser.getGrammar();
+                    for (CsvColumn column : columns) {
+                        for (Rule rule : grammar.getRules()) {
+                            if (column.getName().equals(rule.symbol.getName())) {
+                                String heading = rule.getSymbol().getAttributeValue(InvisibleXml.CSV_HEADING_ATTRIBUTE, null);
+                                if (heading != null) {
+                                    column.setHeader(heading);
+                                }
+                            }
+                        }
+                    }
+
                     out.print(dataTree.asCSV(columns, config.omitCsvHeaders));
                 } else {
                     StringTreeBuilder sbuilder = new StringTreeBuilder(doc.getOptions());

--- a/coffeepot/src/main/java/org/nineml/coffeepot/managers/OutputManager.java
+++ b/coffeepot/src/main/java/org/nineml/coffeepot/managers/OutputManager.java
@@ -339,7 +339,12 @@ public class OutputManager {
                     Grammar grammar = parser.getGrammar();
                     for (CsvColumn column : columns) {
                         for (Rule rule : grammar.getRules()) {
-                            if (column.getName().equals(rule.symbol.getName())) {
+                            String name = rule.symbol.getName();
+                            if (rule.getSymbol().hasAttribute(InvisibleXml.NAME_ATTRIBUTE)) {
+                                name = rule.getSymbol().getAttributeValue(InvisibleXml.NAME_ATTRIBUTE, name);
+                            }
+
+                            if (column.getName().equals(name)) {
                                 String heading = rule.getSymbol().getAttributeValue(InvisibleXml.CSV_HEADING_ATTRIBUTE, null);
                                 if (heading != null) {
                                     column.setHeader(heading);

--- a/documentation/src/main/xml/coffeefilter/pragmas.xml
+++ b/documentation/src/main/xml/coffeefilter/pragmas.xml
@@ -98,9 +98,13 @@ pragmas that it is ignoring.</para>
 <para>Usage:</para>
 <synopsis linenumbering="unnumbered">{[+nineml csv-columns <replaceable>list,of,names</replaceable>]}</synopsis>
 
-<para>Ordinarily, CSV formatted output includes all the columns in (roughly)
-the order they occur in the XML. This pragma allows you to list the
-columns you want output and the order in which you want them output.</para>
+<para>Ordinarily, CSV formatted output includes all the columns in
+(roughly) the order they occur in the XML. This pragma allows you to
+list the columns you want output and the order in which you want them
+output.</para>
+
+<para>If the grammar renames nonterminals, the new “renamed” name
+must be used in the list of column names.</para>
 
 <para>If a column requested does not exist in the document, it is
 ignored. An empty column is not produced.</para>
@@ -223,20 +227,23 @@ that is defined but cannot be reached from the start rule.</para>
 <section xml:id="pragmas-rules">
 <title>Rule pragmas</title>
 
-<para>There following pragmas apply to a rules.</para>
+<para>The following pragmas apply to rules.</para>
 
-<!--
 <section xml:id="pragma-csv-heading">
 <title>csv-heading</title>
 
-<para>Specify the heading title to use in CSV output if the nonterminal defined
-by this is used as the value of a column.</para>
+<para>Specify the heading title to use in CSV output if the
+nonterminal defined by this rule is used as the value of a
+column. (If no heading is specified, the name of the nonterminal
+is used as the heading.)</para>
 
 <para>Usage:</para>
-<synopsis linenumbering="unnumbered">{[nineml xmlns "Heading Title"]}</synopsis>
+<synopsis linenumbering="unnumbered">{[nineml csv-heading "Heading Title"]}</synopsis>
+
+<para>Heading titles may be quoted with either single
+(<code>'</code>) or double (<code>"</code>) quotes.</para>
 
 </section>
--->
 
 <section xml:id="pragma-discard-empty">
 <title>discard-empty</title>
@@ -285,10 +292,6 @@ At first glance, this grammar may seem equivalent:</para>
 entire string “aaba” is consumed by the regular expression, leaving no “a” for the last
 terminal in S to match.
 </para></listitem>
-<listitem><para>The GLL parser doesn’t support multiple regular expressions that start at the
-same place. This is an implementation deficiency. It means that some ambiguous grammars cannot
-be parsed using the GLL parser and regular expressions.
-</para></listitem>
 </orderedlist>
 </section>
 
@@ -310,7 +313,8 @@ only to nonterminals.</para>
 
 <para>An alternative approach is to use the nonterminal renaming
 <link xlink:href="https://lists.w3.org/Archives/Public/public-ixml/2023Jun/0030.html">proposal</link>.
-This is an experimental feature. To use it, you must specify that the
+This is an experimental feature while the renaming proposal is
+under development. To use it, you must specify that the
 grammar version is “<literal>1.1-nineml</literal>”.</para>
 </section>
 

--- a/documentation/src/main/xml/coffeepot/examples/contacts.ixml
+++ b/documentation/src/main/xml/coffeepot/examples/contacts.ixml
@@ -1,3 +1,4 @@
+{[+pragma nineml "https://nineml.org/ns/pragma/"]}
 {[+nineml csv-columns email,name]}
 
 contacts: (contact, NL*)+ .


### PR DESCRIPTION
The `csv-columns` and `csv-heading` pragmas have been broken for a while, probably in all 3.x releases.

This PR fixes the implementation of those pragmas and improves the documentation.