### PR TITLE
Only update versioned documentation on a tagged commit

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -138,7 +138,7 @@ jobs:
             coffeepot/build/distributions/coffeepot-${{ env.CI_TAG }}.zip
 
       - name: Deploy documentation to gh-pages (current version)
-        if: ${{ env.CAN_PUBLISH == 'true' && env.CI_BRANCH == 'main' }}
+        if: ${{ env.CAN_PUBLISH == 'true' && env.CI_BRANCH == 'main' && env.CI_TAG != '' }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: documentation/build/website


### PR DESCRIPTION
When development continues between releases, this PR will assure that the `/current/` documentation gets updated but not the `/3.x.y/` version. I realized this morning that yesterday's commits have actually been pushed into the `/3.2.5/` documentation but that's misleading because those changes aren't *in* 3.2.5.

I'll push out a 3.2.6 to make the situation clearer. (I probably won't attempt to roll-back the 3.2.5 docset.)