### PR TITLE
Release 3.2.6

### DIFF
--- a/documentation/src/main/xml/coffeepot/configuration.xml
+++ b/documentation/src/main/xml/coffeepot/configuration.xml
@@ -264,6 +264,15 @@ element.
 </para>
 </listitem>
 </varlistentry>
+<varlistentry xml:id="prop_validate-vxml">
+<term><property>validate-vxml</property> (boolean)</term>
+<listitem>
+<para>If true (the default), a grammar provided in XML format will be
+validated before it is used. This is an optional feature and is only
+supported if the Jing validation APIs for RELAX NG are on the class
+path.</para>
+</listitem>
+</varlistentry>
 </variablelist>
 
 </chapter>

--- a/documentation/src/main/xml/references/changelog.xml
+++ b/documentation/src/main/xml/references/changelog.xml
@@ -16,6 +16,26 @@ N.B.: the log is used automatically in the release notes for each component.
 -->
 
 <revhistory role="changelog">
+<revision xml:id="v326">
+<revnumber>3.2.6</revnumber>
+<date>2023-09-04</date>
+<revdescription>
+<para>This release is partly a patch to get the current version aligned
+with the documentation. A build oversight meant that updates after 3.2.5
+were being published in the 3.2.5 documentation. That’s potentially confusing;
+releasing 3.2.6 brings the documentation and the release back into alignment.
+Apologies for any confusion.</para>
+<para audience="coffeegrinder"/>
+<para audience="coffeefilter">Restore support for the <code>csv-columns</code>
+and <code>csv-heading</code> pragmas. Added support for validating VXML grammars (i.e., 
+iXML grammars in XML format) before using them. Cleaned up a few small
+problems in the iXML grammar for iXML with pragmas.</para>
+<para audience="coffeesacks"/>
+<para audience="coffeepot">Restore support for the <code>csv-columns</code>
+and <code>csv-heading</code> pragmas. Added a <code>validate-vxml</code> configuration
+property.</para>
+</revdescription>
+</revision>
 <revision xml:id="v325">
 <revnumber>3.2.5</revnumber>
 <date>2023-09-02</date>

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@ org.gradle.parallel=false
 org.gradle.caching=false
 systemProp.org.nineml.logging.defaultLogLevel=info
 
-currentReleaseVersion=3.2.5
-ninemlVersion=3.2.5
+currentReleaseVersion=3.2.6
+ninemlVersion=3.2.6
 
 potTitle=CoffeePot
 potName=coffeepot


### PR DESCRIPTION
There are a couple of small fixes in 3.2.6:
* The `csv-columns` and `csv-heading` pragmas work again
* Support for validating VXML grammars
* A few tweaks to the iXML grammar for iXML with pragmas
But the main reason for the release is so that the documentation aligns with the release.