### PR TITLE
Handle epsilon correctly when creating forest nodes from GLL

### DIFF
--- a/coffeefilter/src/main/java/org/nineml/coffeefilter/trees/ContentHandlerAdapter.java
+++ b/coffeefilter/src/main/java/org/nineml/coffeefilter/trees/ContentHandlerAdapter.java
@@ -62,16 +62,20 @@ public class ContentHandlerAdapter implements TreeBuilder {
         assert nodeStack.size() == 1;
         DocumentNode doc = (DocumentNode) nodeStack.get(0);
         Node root = doc.children.isEmpty() ? null : doc.children.get(0);
-        if (root != null) {
-            if (root instanceof TextNode) {
-                throw IxmlException.notSingleRooted("(text node)");
+        int rootElements = 0;
+        for (Node child : doc.children) {
+            if ((child instanceof TextNode) && !child.getStringValue().trim().isEmpty()) {
+                throw IxmlException.notSingleRooted(child.getStringValue());
             }
             if (root instanceof AttributeNode) {
                 throw IxmlException.attributeRoot(root.getName());
             }
+            if ((child instanceof ElementNode)) {
+                rootElements++;
+            }
         }
 
-        if (doc.children.size() != 1) {
+        if (rootElements != 1) {
             throw IxmlException.notSingleRooted("(document)");
         }
 

--- a/coffeefilter/src/test/resources/iss-042.ixml
+++ b/coffeefilter/src/test/resources/iss-042.ixml
@@ -1,0 +1,45 @@
+    -json: ws, -value, ws.
+    value: map
+         | array
+         | number
+         | string
+         | boolean
+         | null
+         .
+  boolean: 'false'
+         | 'true'
+         .
+     null: -'null'.
+      map: -'{', ( ws, member )**( ws, -',' ), ws , -'}'.
+   member: key, ws, -':', ws, value.
+      key: -string.
+    array: -'[', ( ws, -value )**( ws, -','), ws, -']'.
+    number: '-'?, int, frac?, exp?.
+-digit1-9: ['1'-'9'].
+       -e: ['eE'].
+     -exp: e, ['-+']?, DIGIT+.
+    -frac: '.', DIGIT+.
+     -int: '0'
+         | digit1-9, DIGIT*
+         .
+   string: -'"', char*, -'"'.
+    -char: ~['"\'; #9; #a; #d]
+         | -'\', escaped
+         .
+ -escaped: '"'
+         | '\'
+         | '/'
+         | -'b', +#8
+         | -'f', +#c
+         | -'n', +#a
+         | -'r', +#d
+         | -'t', +#9
+         | unicode
+         .
+  unicode: -'u', code.
+    @code: HEXDIG, HEXDIG, HEXDIG, HEXDIG.
+   -DIGIT: ['0'-'9'].
+  -HEXDIG: DIGIT
+         | ['a'-'f'; 'A'-'F']
+         .
+      -ws: [' '; #9; #a; #d; 'x']*.

--- a/coffeegrinder/src/main/java/org/nineml/coffeegrinder/parser/ParseForestGLL.java
+++ b/coffeegrinder/src/main/java/org/nineml/coffeegrinder/parser/ParseForestGLL.java
@@ -56,7 +56,9 @@ public class ParseForestGLL extends ParseForest {
                 for (int pos = leftExtent; pos < rightExtent; pos++) {
                     sb.append(inputTokens[pos].getValue());
                 }
-                symbol = new TerminalSymbol(TokenString.get(sb.toString()), attr);
+                if (symbol != TerminalSymbol.EPSILON) {
+                    symbol = new TerminalSymbol(TokenString.get(sb.toString()), attr);
+                }
             }
         }
 


### PR DESCRIPTION
When constructing forest nodes from a GLL parse, preserve epsilon nonterminals; don't turn them into empty strings.

Fix #42 
