### PR TITLE
Correct the attribute used to identify an alternate name in a `naming`

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -12,7 +12,7 @@ jobs:
       tag: ${{ steps.check_step.outputs.tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -60,7 +60,7 @@ jobs:
       CI_TAG: ${{ needs.check_branch.outputs.tag }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build and test
         run: |
@@ -74,7 +74,7 @@ jobs:
           ./gradlew -PparserType=earley -PsaxonGroup=com.saxonica -PsaxonEdition=Saxon-EE dist docset website
 
       - name: Publish coffeegrinder release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: ${{ env.CAN_PUBLISH == 'true' && env.CI_BRANCH == 'main' && env.CI_TAG != '' }}
         with:
           repository: nineml/coffeegrinder
@@ -99,7 +99,7 @@ jobs:
           rm -f `pwd`/secret.gpg
 
       - name: Publish coffeefilter release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: ${{ env.CAN_PUBLISH == 'true' && env.CI_BRANCH == 'main' && env.CI_TAG != '' }}
         with:
           repository: nineml/coffeefilter
@@ -112,7 +112,7 @@ jobs:
             coffeefilter/build/distributions/coffeefilter-${{ env.CI_TAG }}.zip
 
       - name: Publish coffeesacks release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: ${{ env.CAN_PUBLISH == 'true' && env.CI_BRANCH == 'main' && env.CI_TAG != '' }}
         with:
           repository: nineml/coffeesacks
@@ -125,7 +125,7 @@ jobs:
             coffeesacks/build/distributions/coffeesacks-${{ env.CI_TAG }}.zip
 
       - name: Publish coffeepot release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: ${{ env.CAN_PUBLISH == 'true' && env.CI_BRANCH == 'main' && env.CI_TAG != '' }}
         with:
           repository: nineml/coffeepot

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
       tag: ${{ steps.check_step.outputs.tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -59,7 +59,7 @@ jobs:
       CI_PULL: ${{ github.event.number }}
     steps:
       - name: Checkout the pull request
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0

--- a/coffeefilter/src/main/java/org/nineml/coffeefilter/model/XNode.java
+++ b/coffeefilter/src/main/java/org/nineml/coffeefilter/model/XNode.java
@@ -172,7 +172,7 @@ public abstract class XNode {
             case "nonterminal":
                 mark = attributes.getValue("mark");
                 String nname = attributes.getValue("name");
-                String nrename = attributes.getValue("rename");
+                String nrename = attributes.getValue("alias");
                 if (mark == null) {
                     child = new INonterminal(this, nname, nrename);
                 } else {
@@ -194,7 +194,7 @@ public abstract class XNode {
             case "rule":
                 mark = attributes.getValue("mark");
                 String lhs_name = attributes.getValue("name");
-                String lhs_rename = attributes.getValue("rename");
+                String lhs_rename = attributes.getValue("alias");
                 if (mark == null) {
                     child = new IRule(this, lhs_name, lhs_rename,'^');
                 } else {

--- a/coffeefilter/src/main/resources/org/nineml/coffeefilter/ixml2.ixml
+++ b/coffeefilter/src/main/resources/org/nineml/coffeefilter/ixml2.ixml
@@ -33,10 +33,10 @@
           sep: factor.
   nonterminal: naming.
 
-      -naming: (mark, s)?, name, s, (-">", s, rename, s)?.
+      -naming: (mark, s)?, name, s, (-">", s, alias, s)?.
 
         @name: namestart, namefollower*.
-      @rename: name.
+       @alias: name.
 
    -namestart: ["_"; L].
 -namefollower: namestart; ["-.·‿⁀"; Nd; Mn].

--- a/coffeefilter/src/main/resources/org/nineml/coffeefilter/ixml2.xml
+++ b/coffeefilter/src/main/resources/org/nineml/coffeefilter/ixml2.xml
@@ -266,7 +266,7 @@
                <alt>
                   <literal tmark='-' string='&gt;'/>
                   <nonterminal name='s'/>
-                  <nonterminal name='rename'/>
+                  <nonterminal name='alias'/>
                   <nonterminal name='s'/>
                </alt>
             </alts>
@@ -281,7 +281,7 @@
          </repeat0>
       </alt>
    </rule>
-   <rule mark='@' name='rename'>
+   <rule mark='@' name='alias'>
       <alt>
          <nonterminal name='name'/>
       </alt>

--- a/coffeefilter/src/main/resources/org/nineml/coffeefilter/pragmas2.ixml
+++ b/coffeefilter/src/main/resources/org/nineml/coffeefilter/pragmas2.ixml
@@ -37,10 +37,10 @@ comment-or-pragma>comment: -"{", (cchar; comment-or-pragma)*, -"}".
   -annotation: (pragma, sp)?, (mark, sp)?.
           -sp: (whitespace; comment; pragma)*.
 
-      -naming: name, s, (-">", s, rename, s)?.
+      -naming: name, s, (-">", s, alias, s)?.
 
         @name: namestart, namefollower*.
-      @rename: name.
+       @alias: name.
 
    -namestart: ["_"; L].
 -namefollower: namestart; ["-.·‿⁀"; Nd; Mn].

--- a/coffeefilter/src/main/resources/org/nineml/coffeefilter/pragmas2.xml
+++ b/coffeefilter/src/main/resources/org/nineml/coffeefilter/pragmas2.xml
@@ -364,7 +364,7 @@
                <alt>
                   <literal tmark='-' string='&gt;'/>
                   <nonterminal name='s'/>
-                  <nonterminal name='rename'/>
+                  <nonterminal name='alias'/>
                   <nonterminal name='s'/>
                </alt>
             </alts>
@@ -379,7 +379,7 @@
          </repeat0>
       </alt>
    </rule>
-   <rule mark='@' name='rename'>
+   <rule mark='@' name='alias'>
       <alt>
          <nonterminal name='name'/>
       </alt>

--- a/coffeefilter/src/test/resources/test-suite-exceptions-earley-pedantic.txt
+++ b/coffeefilter/src/test/resources/test-suite-exceptions-earley-pedantic.txt
@@ -1,2 +1,3 @@
 set "ignored" because it doesn't really exist.
 set "unicode-classes" because Java 11’s version of Unicode isn’t recent enough.
+set "unicode-version-check" because the test driver doesn’t support dependencies.

--- a/coffeefilter/src/test/resources/test-suite-exceptions-earley.txt
+++ b/coffeefilter/src/test/resources/test-suite-exceptions-earley.txt
@@ -1,2 +1,3 @@
 set "ignored" because it doesn't really exist.
 set "unicode-classes" because Java 11’s version of Unicode isn’t recent enough.
+set "unicode-version-check" because the test driver doesn’t support dependencies.

--- a/coffeefilter/src/test/resources/test-suite-exceptions-gll-pedantic.txt
+++ b/coffeefilter/src/test/resources/test-suite-exceptions-gll-pedantic.txt
@@ -1,2 +1,3 @@
 set "ignored" because it doesn't really exist.
 set "unicode-classes" because Java 11’s version of Unicode isn’t recent enough.
+set "unicode-version-check" because the test driver doesn’t support dependencies.

--- a/coffeefilter/src/test/resources/test-suite-exceptions-gll.txt
+++ b/coffeefilter/src/test/resources/test-suite-exceptions-gll.txt
@@ -1,5 +1,6 @@
 set "ignored" because it doesn't really exist.
 set "unicode-classes" because Java 11’s version of Unicode isn’t recent enough.
+set "unicode-version-check" because the test driver doesn’t support dependencies.
 
 
 

--- a/coffeefilter/tools/test-report/test-report.xsl
+++ b/coffeefilter/tools/test-report/test-report.xsl
@@ -613,6 +613,25 @@
   </details>
 </xsl:template>
 
+<xsl:template match="t:dependencies[not(preceding-sibling::t:dependencies)]">
+  <xsl:variable name="dep" select="../t:dependencies"/>
+
+  <!-- The only dependency (currently!) is @Unicode-version -->
+  <details>
+    <summary>Dependencies</summary>
+    <p>
+      <xsl:text>Unicode version</xsl:text>
+      <xsl:if test="count($dep) gt 1">s</xsl:if>
+      <xsl:text>: </xsl:text>
+      <xsl:sequence select="string-join($dep/@Unicode-version, ', ')"/>
+      <xsl:text>.</xsl:text>
+    </p>
+  </details>
+</xsl:template>
+
+<xsl:template match="t:dependencies[preceding-sibling::t:dependencies]"
+              priority="10"/>
+
 <xsl:template match="t:ixml-grammar-ref">
   <details>
     <summary>Invisible XML Grammar</summary>

--- a/documentation/src/main/xml/references/changelog.xml
+++ b/documentation/src/main/xml/references/changelog.xml
@@ -16,6 +16,27 @@ N.B.: the log is used automatically in the release notes for each component.
 -->
 
 <revhistory role="changelog">
+<revision xml:id="v327">
+<revnumber>3.2.7</revnumber>
+<date>2024-10-29</date>
+<revdescription>
+<para>One of the new features in iXML (new since 1.0) is the ability to
+<link xlink:href="https://invisiblexml.org/current/#rules">rename
+elements</link> in the serialized output. Using a <code>&gt;</code> after a nonterminal
+will rename it. In a rule, <code>A&gt;B</code>, means match the nonterminal <code>A</code>,
+but serialize the result as <code>B</code>.</para>
+<para>Apparently, I implemented a very early draft of that idea because the specification
+calls the new name an <code>alias</code> where <emphasis>CoffeeFilter</emphasis> called
+it a <code>rename</code>.</para>
+<para audience="coffeegrinder"/>
+<para audience="coffeefilter">Rename “<code>rename</code>” to “<code>alias</code>” in the
+XML serialization of iXML grammars. This upgrade invalidates any XML serializations using
+the renaming feature that were generated with an earlier version of <emphasis>CoffeeFilter</emphasis>.
+</para>
+<para audience="coffeesacks"/>
+<para audience="coffeepot"/>
+</revdescription>
+</revision>
 <revision xml:id="v326">
 <revnumber>3.2.6</revnumber>
 <date>2023-09-04</date>

--- a/documentation/tools/doclet2db.xsl
+++ b/documentation/tools/doclet2db.xsl
@@ -28,9 +28,9 @@
 <xsl:template match="/" name="xsl:initial-template">
   <xsl:variable name="class"
                 select="/*/*/d:class[starts-with(@package, $package-prefix)
-                                     and @type=$className]
+                                     and @name=$className]
                         |/*/*/d:interface[starts-with(@package, $package-prefix)
-                                          and @type=$className]"/>
+                                          and @name=$className]"/>
   <xsl:choose>
     <xsl:when test="empty($class)">
       <xsl:message terminate="yes">Failed to find a class named {$className}</xsl:message>
@@ -48,7 +48,7 @@
   <section>
     <xsl:attribute name="xml:id" select="'c_' || @fullname"/>
     <title>
-      <xsl:sequence select="@type/string()"/>
+      <xsl:sequence select="@name/string()"/>
     </title>
 
     <para>
@@ -129,7 +129,7 @@
               <xsl:text> class.</xsl:text>
             </xsl:when>
             <xsl:otherwise>
-              <interfacename>{@type/string()}</interfacename>
+              <interfacename>{@name/string()}</interfacename>
               <xsl:text> interface.</xsl:text>
             </xsl:otherwise>
           </xsl:choose>
@@ -234,7 +234,7 @@
         </xsl:if>
         <xsl:choose>
           <xsl:when test="self::d:constructor">
-            <xsl:sequence select="../@type/string()"/>
+            <xsl:sequence select="../@name/string()"/>
           </xsl:when>
           <xsl:otherwise>
             <xsl:sequence select="@name/string()"/>

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@ org.gradle.parallel=false
 org.gradle.caching=false
 systemProp.org.nineml.logging.defaultLogLevel=info
 
-currentReleaseVersion=3.2.6
-ninemlVersion=3.2.6
+currentReleaseVersion=3.2.7
+ninemlVersion=3.2.7
 
 potTitle=CoffeePot
 potName=coffeepot
@@ -17,10 +17,10 @@ grinderName=coffeegrinder
 sacksTitle=CoffeeSacks
 sacksName=coffeesacks
 
-xmlresolverVersion=5.2.1
-docbookVersion=5.2CR5
-xslTNGversion=2.1.9
-xmldocletVersion=0.1.0
+xmlresolverVersion=6.0.10
+docbookVersion=5.2
+xslTNGversion=2.4.1
+xmldocletVersion=0.16.0
 
 // If you change saxonVersions, also update the workflows!
 saxonPomVersionList=[11.0,13.0)

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
I can find no record of any version of the iXML grammar being published where the nonterminal `rename` was used. I can't explain how I came to use that instead of `alias`. Working in advance of the first actual publication of a spec that contained it is my best guess.