### PR TITLE
Fix an apparently common typo: “ambigous”

### DIFF
--- a/coffeegrinder/src/main/java/org/nineml/coffeegrinder/parser/HygieneReport.java
+++ b/coffeegrinder/src/main/java/org/nineml/coffeegrinder/parser/HygieneReport.java
@@ -221,7 +221,7 @@ public class HygieneReport {
     }
 
     /**
-     * Did the dk.brics.grammar.ambiguity analyzer report the grammar unambigous?
+     * Did the dk.brics.grammar.ambiguity analyzer report the grammar unambiguous?
      * @return true, if the grammar is unambiguous
      */
     public boolean provablyUnambiguous() {

--- a/documentation/src/main/xml/coffeefilter/general.xml
+++ b/documentation/src/main/xml/coffeefilter/general.xml
@@ -106,7 +106,7 @@ send events to a SAX content handler to construct the tree.</para>
   parse="text"
 /></programlisting>
 
-<para>Beware that in an infinitely ambigous forest, the number returned is wildely inaccurate
+<para>Beware that in an infinitely ambiguous forest, the number returned is wildely inaccurate
 (in as much as it is <emphasis>infinitely</emphasis> less than ∞!). It tells you something about
 how the forest divides into ambiguous branches, but doesn’t attempt to account for loops.</para>
 </section>

--- a/documentation/src/main/xml/coffeegrinder/coffeegrinder.xml
+++ b/documentation/src/main/xml/coffeegrinder/coffeegrinder.xml
@@ -250,7 +250,7 @@ The print stream and string tree builders represent the trees using XML.
   parse="text"
 /></programlisting>
 
-<para>Beware that in an infinitely ambigous forest, the number returned is wildely inaccurate
+<para>Beware that in an infinitely ambiguous forest, the number returned is wildely inaccurate
 (in as much as it is <emphasis>infinitely</emphasis> less than ∞!). It tells you something about
 how the forest divides into ambiguous branches, but doesn’t attempt to account for loops.</para>
 </section>

--- a/documentation/src/main/xml/coffeepot/ambiguity.xml
+++ b/documentation/src/main/xml/coffeepot/ambiguity.xml
@@ -82,7 +82,7 @@ can be useful.</para>
 </mediaobject>
 </figure>
 
-<para>It is possible for grammars to be infinitely ambigous. Consider
+<para>It is possible for grammars to be infinitely ambiguous. Consider
 this trivial grammar:</para>
 
 <example xml:id="ambig02">


### PR DESCRIPTION
Fix #51