### PR TITLE
Attempt to resolve a build issue in GitHub CI

### DIFF
--- a/coffeefilter/build.gradle
+++ b/coffeefilter/build.gradle
@@ -10,6 +10,7 @@ buildscript {
       force 'xml-apis:xml-apis:1.4.01'
       force "${saxonGroup}:${saxonEdition}:${saxonVersion}"
       force "org.xmlresolver:xmlresolver:${xmlresolverVersion}"
+      force "xerces:xercesImpl:${xercesVersion}"
     }
   }
 
@@ -57,6 +58,7 @@ configurations.all {
     force 'xml-apis:xml-apis:1.4.01'
     force "${saxonGroup}:${saxonEdition}:${saxonVersion}"
     force "org.xmlresolver:xmlresolver:${xmlresolverVersion}"
+    force "xerces:xercesImpl:${xercesVersion}"
   }
 }
 
@@ -68,12 +70,12 @@ configurations {
 dependencies {
   implementation project(':coffeegrinder')
   implementation (
-    [group: 'org.relaxng', name: 'jing', version: '20220510']
+    [group: 'org.relaxng', name: 'jing', version: jingVersion]
   )
 
   testImplementation (
     [group: 'com.saxonica', name: 'Saxon-EE', version: saxonVersion],
-    [group: 'org.relaxng', name: 'jing', version: '20220510'],
+    [group: 'org.relaxng', name: 'jing', version: jingVersion],
     files(saxonLicenseDir)
   )
   testsuite (
@@ -185,16 +187,17 @@ task testSuite(type: JavaExec,
   args javaArgs
 }
 
-task testSuiteReport(type: SaxonXsltTask, dependsOn: ["testSuite"]) {
+task testSuiteReport(type: JavaExec, dependsOn: ["testSuite"]) {
   inputs.files fileTree(dir: "${projectDir}/ixml/tests")
   inputs.files files(testSuite)
 
-  input "${projectDir}/ixml/tests/test-catalog.xml"
-  stylesheet "${projectDir}/tools/test-report/test-report.xsl"
-  output "${buildDir}/test-report/index.html"
-  parameters (
-    'test-report.xml': "${buildDir}/test-report-${parserType}.xml"
-  )
+  classpath = configurations.testsuite
+
+  mainClass = "net.sf.saxon.Transform"
+  args = ["-s:${projectDir}/ixml/tests/test-catalog.xml",
+          "-o:${buildDir}/test-report/index.html",
+          "-xsl:${projectDir}/tools/test-report/test-report.xsl",
+          "test-report.xml=${buildDir}/test-report-${parserType}.xml"]
 
   doLast {
     copy {

--- a/coffeegrinder/build.gradle
+++ b/coffeegrinder/build.gradle
@@ -10,6 +10,7 @@ buildscript {
       force 'xml-apis:xml-apis:1.4.01'
       force "${saxonGroup}:${saxonEdition}:${saxonVersion}"
       force "org.xmlresolver:xmlresolver:${xmlresolverVersion}"
+      force "xerces:xercesImpl:${xercesVersion}"
     }
   }
 
@@ -47,6 +48,7 @@ configurations.all {
     force 'xml-apis:xml-apis:1.4.01'
     force "${saxonGroup}:${saxonEdition}:${saxonVersion}"
     force "org.xmlresolver:xmlresolver:${xmlresolverVersion}"
+    force "xerces:xercesImpl:${xercesVersion}"
   }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,8 @@ xmlresolverVersion=6.0.10
 docbookVersion=5.2
 xslTNGversion=2.4.1
 xmldocletVersion=0.16.0
+xercesVersion=2.12.2
+jingVersion=20241231
 
 // If you change saxonVersions, also update the workflows!
 saxonPomVersionList=[11.0,13.0)


### PR DESCRIPTION
Attempting to publish the 3.2.8 release, I discovered that the build failed in CI because of an ugly class-cast exception in Xerces. It’s unclear what causes this. Web searching reveals some suggestions, but many involve fussing with the loader and pointing it at private classes in the com.sun packages. If that even still works, it’s ugly. My best hypothesis is that it’s caused by mixing different versions of Xerces on the class path.

The changes in this PR seem to make the problem go away. But they’re not very satisfying. You can’t point at this PR and say, “oh, yes, I see how that fixes it.” But it fixes it and I want to rewrite all the build scripts in Kotlin anyway, so I’m just pressing on.