### PR TITLE
Make sure there’s a namespace declaration for the ixml namespace

### DIFF
--- a/coffeefilter/src/main/java/org/nineml/coffeefilter/trees/SimpleTree.java
+++ b/coffeefilter/src/main/java/org/nineml/coffeefilter/trees/SimpleTree.java
@@ -107,10 +107,16 @@ public class SimpleTree {
         if (name != null) {
             sb.append("<").append(name);
 
+            boolean ixmlNS = false;
             for (String attname : attributes.keySet()) {
+                ixmlNS = ixmlNS || attname.startsWith("ixml:");
                 sb.append(" ").append(attname).append("=\"");
                 sb.append(TreeUtils.xmlEscapeAttribute(attributes.get(attname)));
                 sb.append("\"");
+            }
+
+            if (ixmlNS) {
+                sb.append(" xmlns:ixml=\"http://invisiblexml.org/NS\"");
             }
 
             if (children.isEmpty()) {


### PR DESCRIPTION
When outputting a simple tree for a failure document, make sure that the xmlns:ixml namespace binding is added.