### PR TITLE
If not being pedantic, allow a single text node as an “xml” result

### DIFF
--- a/coffeefilter/src/main/java/org/nineml/coffeefilter/trees/ContentHandlerAdapter.java
+++ b/coffeefilter/src/main/java/org/nineml/coffeefilter/trees/ContentHandlerAdapter.java
@@ -65,7 +65,9 @@ public class ContentHandlerAdapter implements TreeBuilder {
         int rootElements = 0;
         for (Node child : doc.children) {
             if ((child instanceof TextNode) && !child.getStringValue().trim().isEmpty()) {
-                throw IxmlException.notSingleRooted(child.getStringValue());
+                if (getOptions().getPedantic()) {
+                    throw IxmlException.notSingleRooted(child.getStringValue());
+                }
             }
             if (root instanceof AttributeNode) {
                 throw IxmlException.attributeRoot(root.getName());
@@ -76,7 +78,9 @@ public class ContentHandlerAdapter implements TreeBuilder {
         }
 
         if (rootElements != 1) {
-            throw IxmlException.notSingleRooted("(document)");
+            if (getOptions().getPedantic() || rootElements > 1) {
+                throw IxmlException.notSingleRooted("(document)");
+            }
         }
 
         try {

--- a/coffeefilter/src/test/resources/test-suite-exceptions-earley.txt
+++ b/coffeefilter/src/test/resources/test-suite-exceptions-earley.txt
@@ -1,3 +1,4 @@
 set "ignored" because it doesn't really exist.
 set "unicode-classes" because Java 11’s version of Unicode isn’t recent enough.
 set "unicode-version-check" because the test driver doesn’t support dependencies.
+set "rootless" because this is allowed if pedantic is false.

--- a/coffeefilter/src/test/resources/test-suite-exceptions-gll.txt
+++ b/coffeefilter/src/test/resources/test-suite-exceptions-gll.txt
@@ -1,8 +1,4 @@
 set "ignored" because it doesn't really exist.
 set "unicode-classes" because Java 11’s version of Unicode isn’t recent enough.
 set "unicode-version-check" because the test driver doesn’t support dependencies.
-
-
-
-
-
+set "rootless" because this is allowed if pedantic is false.


### PR DESCRIPTION
This technically violates D01 and D06 in the specification, but it’s not a completely unreasonable thing to want to do.