### PR TITLE
Documentation fixes

### DIFF
--- a/coffeepot/examples/err01.ixml
+++ b/coffeepot/examples/err01.ixml
@@ -1,4 +1,4 @@
-list: word + -',' .
+list: word ++ -',' .
 word: c, v, c ; c, v, v
 -c: ["bcdfghjklmnpqrstvwxyz"] .
 -v: ["aeiouy" ].

--- a/coffeepot/examples/err02.ixml
+++ b/coffeepot/examples/err02.ixml
@@ -1,4 +1,4 @@
-list: word + -',' .
+list: word ++ -',' .
 word: c, v, c ; c, v, v .
 -c: ["bcdfghjklmnpqrstvwxyz"] .
 -v: ["aeiouy" ].

--- a/documentation/src/main/xml/coffeepot/cli.xml
+++ b/documentation/src/main/xml/coffeepot/cli.xml
@@ -83,6 +83,9 @@ the text or XML formats.
 <para>Specifies the input file. If unspecified, the remaining command line arguments
 are taken as the input, separated by single spaces.
 </para>
+<para>If the input file is just a single hyphen, <code>-</code>,
+<application>CoffeePot</application> will read from standard input.
+</para>
 </listitem>
 </varlistentry>
 </variablelist>

--- a/documentation/src/main/xml/coffeepot/debugging.xml
+++ b/documentation/src/main/xml/coffeepot/debugging.xml
@@ -48,26 +48,36 @@ rule is missing the terminating “.”.</para>
 
 <para>Which does work:</para>
 
-<programlisting linenumbering="unnumbered"
+<screen
 ><![CDATA[$ coffeepot -pp -g:examples/err02.ixml cat,sat,hat
 <list>
    <word>cat</word>
    <word>sat</word>
    <word>hat</word>
-</list>]]></programlisting>
+</list>]]></screen>
 
 <para>Once your grammar works, you can start feeding inputs to it. Some of
 those won’t work.</para>
 
-<programlisting linenumbering="unnumbered"
+<screen
 ><![CDATA[$ coffeepot -pp -g:examples/err02.ixml frog,sat,log
-<fail xmlns:ixml="http://invisiblexml.org/NS" ixml:state="failed">
+<fail xmlns:ixml='http://invisiblexml.org/NS' ixml:state='failed'>
    <line>1</line>
-   <column>3</column>
+   <column>2</column>
    <pos>2</pos>
    <unexpected>r</unexpected>
-   <permitted>["aeuiyo"]</permitted>
-</fail>]]></programlisting>
+   <permitted>['aeiouy']</permitted>
+   <could-be-next>
+      <in rule='v'>
+         <tokens>['aeiouy']</tokens>
+      </in>
+   </could-be-next>
+   <unfinished>
+      <open rule='word' start='1' end='1'>
+         <input>f</input>
+      </open>
+   </unfinished>
+</fail>]]></screen>
 
 <para>There is no universally correct answer to the question: is your
 grammar incorrect or is your input incorrect? In fact, if what you
@@ -79,7 +89,7 @@ not</emphasis> a sentence in the grammar, then
 expect the input to match, the next question to answer is, why didn’t
 it?</para>
 
-<para>The “parse-failed” document attempts to identify where the error
+<para>The “fail” document attempts to identify where the error
 occurred. As before, what we see in the error is where the parser was
 when it couldn’t continue. In this case, note that it read as far as
 the third character, but in fact had failed at the second, the “r”.
@@ -111,25 +121,39 @@ details, but beware, you sometimes get <emphasis>a lot</emphasis> of detail!
 The <option>--show-chart</option> option tells <application>coffeepot</application> to
 print the state chart that was current at the moment of failure.</para>
 
-<programlisting linenumbering="unnumbered"
+<screen
 ><![CDATA[$ coffeepot -pp -g:examples/err02.ixml --show-chart frog,sat,log
-<parse-failed xmlns:ixml="http://invisiblexml.org/NS" ixml:state="failed">
-   <last-token line="1" column="3" token-count="2">'r'</last-token>
+<fail xmlns:ixml='http://invisiblexml.org/NS' ixml:state='failed'>
+   <line>1</line>
+   <column>2</column>
+   <pos>2</pos>
+   <unexpected>r</unexpected>
+   <permitted>['aeiouy']</permitted>
+   <could-be-next>
+      <in rule='v'>
+         <tokens>['aeiouy']</tokens>
+      </in>
+   </could-be-next>
+   <unfinished>
+      <open rule='word' start='1' end='1'>
+         <input>f</input>
+      </open>
+   </unfinished>
    <chart>
-      <row n="0">
-         <item>$$ ⇒ • list / 0 / null</item>
-         <item>list ⇒ • $1 / 0 / null</item>
-         <item>$1 ⇒ • word $2ⁿ / 0 / null</item>
-         <item>word ⇒ • c v c / 0 / null</item>
-         <item>word ⇒ • c v v / 0 / null</item>
+      <row n='0'>  
+         <item>$$ ⇒ • list / 0</item>  
+         <item>list ⇒ • $1_word-plus-sep / 0</item>  
+         <item>$1_word-plus-sep ⇒ • word $2_L,-starⁿ / 0</item>  
+         <item>word ⇒ • c v c / 0</item>  
+         <item>word ⇒ • c v v / 0</item>
       </row>
-      <row n="1">
-         <item>c ⇒ ["bcdfghjklmnpqrstvwxyz"] • / 0 / c, 0, 1</item>
-         <item>word ⇒ c • v c / 0 / c, 0, 1</item>
+      <row n='1'>  
+         <item>c ⇒ ['bcdfghjklmnpqrstvwxyz'] • / 0 / c, 0, 1</item>  
+         <item>word ⇒ c • v c / 0 / c, 0, 1</item>  
          <item>word ⇒ c • v v / 0 / c, 0, 1</item>
       </row>
    </chart>
-</parse-failed>]]></programlisting>
+</fail>]]></screen>
 
 <para>To understand the state chart, it will be useful to know something about how
 an <link xlink:href="https://en.wikipedia.org/wiki/Earley_parser">Earley parser</link>
@@ -158,16 +182,26 @@ the next match, a vowel in both cases. Not surprising since “r” isn’t a vo
 
 <programlisting linenumbering="unnumbered"
 ><![CDATA[$ coffeepot -pp -g:examples/err02.ixml  cat,ate,rat
-<fail xmlns:ixml="http://invisiblexml.org/NS" ixml:state="failed">
+<fail xmlns:ixml='http://invisiblexml.org/NS' ixml:state='failed'>
    <line>1</line>
-   <column>6</column>
+   <column>5</column>
    <pos>5</pos>
    <unexpected>a</unexpected>
-   <permitted>["bcdfghjklmnpqrstvwxyz"]</permitted>
+   <permitted>['bcdfghjklmnpqrstvwxyz']</permitted>
+   <completions>
+      <completed rule='word' start='1' end='3'>
+         <input>cat</input>
+      </completed>
+   </completions>
+   <could-be-next>
+      <in rule='c'>
+         <tokens>['bcdfghjklmnpqrstvwxyz']</tokens>
+      </in>
+   </could-be-next>
 </fail>]]></programlisting>
 
 <para>The state chart isn’t the only tool we have to understand what went wrong.
-We can also look at what was in the parse forest with the <option>--graph-svg</option>
+We can also look at what was in the parse forest with the <option>--graph</option>
 option (if you <link linkend="configuration">have configured</link> GraphViz).</para>
 
 <figure xml:id="err02-forest-cat.svg">


### PR DESCRIPTION
Document -i:- as a way to parse from stdin.

Update the examples in the section about finding errors.