### PR TITLE
More aggressively restrict the Saxon version in the build scripts

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -8,7 +8,7 @@ props.each { key, val -> project.ext."$key" = val }
 repositories {
   mavenLocal()
   mavenCentral()
-  maven { url "https://dev.saxonica.com/maven" }
+  maven { url "https://maven.saxonica.com/maven" }
 }
 
 configurations.all {
@@ -21,9 +21,15 @@ configurations.all {
 
 dependencies {
   implementation(
-    [group: saxonGroup, name: saxonEdition, version: saxonVersion],
     [group: 'org.docbook', name: 'schemas-docbook', version: docbookVersion],
     [group: 'org.docbook', name: 'docbook-xslTNG', version: xslTNGversion],
     [group: 'nu.validator.htmlparser', name: 'htmlparser', version: '1.4']
   )
+
+  implementation ("${saxonGroup}:${saxonEdition}") {
+    exclude group: "net.sf.saxon", module: "Saxon-HE"
+    version {
+      strictly "${saxonVersion}"
+    }
+  }
 }

--- a/coffeefilter/build.gradle
+++ b/coffeefilter/build.gradle
@@ -2,7 +2,7 @@ buildscript {
   repositories {
     mavenLocal()
     mavenCentral()
-    maven { url "https://dev.saxonica.com/maven" }
+    maven { url "https://maven.saxonica.com/maven" }
   }
 
   configurations.all {
@@ -40,7 +40,7 @@ import java.nio.file.Files
 repositories {
   mavenLocal()
   mavenCentral()
-  maven { url "https://dev.saxonica.com/maven" }
+  maven { url "https://maven.saxonica.com/maven" }
 }
 
 // Set saxonLicenseDir in gradle.properties, or from the
@@ -73,24 +73,45 @@ dependencies {
     [group: 'org.relaxng', name: 'jing', version: jingVersion]
   )
 
+  implementation ("${saxonGroup}:${saxonEdition}") {
+    exclude group: "net.sf.saxon", module: "Saxon-HE"
+    version {
+      strictly "${saxonVersion}"
+    }
+  }
+
   testImplementation (
-    [group: 'com.saxonica', name: 'Saxon-EE', version: saxonVersion],
     [group: 'org.relaxng', name: 'jing', version: jingVersion],
     files(saxonLicenseDir)
   )
+
+  testImplementation("com.saxonica:Saxon-EE") {
+    exclude group: "net.sf.saxon", module: "Saxon-HE"
+    version {
+      strictly "${saxonVersion}"
+    }
+  }
+
   testsuite (
     files("${buildDir}/classes/java/main"),
     files("${buildDir}/classes/java/test"),
     files("${buildDir}/resources/main"),
     files("${buildDir}/resources/test")
   )
+
   documentation (
     project(':coffeegrinder'),
-    [group: saxonGroup, name: saxonEdition, version: saxonVersion],
     [group: 'org.docbook', name: 'schemas-docbook', version: docbookVersion],
     [group: 'org.docbook', name: 'docbook-xslTNG', version: xslTNGversion],
     [group: 'com.saxonica', name: 'xmldoclet', version: xmldocletVersion],
   )
+
+  documentation("${saxonGroup}:${saxonEdition}") {
+    exclude group: "net.sf.saxon", module: "Saxon-HE"
+    version {
+      strictly "${saxonVersion}"
+    }
+  }
 }
 
 testing {

--- a/coffeegrinder/build.gradle
+++ b/coffeegrinder/build.gradle
@@ -2,7 +2,7 @@ buildscript {
   repositories {
     mavenLocal()
     mavenCentral()
-    maven { url "https://dev.saxonica.com/maven" }
+    maven { url "https://maven.saxonica.com/maven" }
   }
 
   configurations.all {
@@ -40,7 +40,7 @@ import java.nio.file.Files
 repositories {
   mavenLocal()
   mavenCentral()
-  maven { url "https://dev.saxonica.com/maven" }
+  maven { url "https://maven.saxonica.com/maven" }
 }
 
 configurations.all {

--- a/coffeepot/build.gradle
+++ b/coffeepot/build.gradle
@@ -2,7 +2,7 @@ buildscript {
   repositories {
     mavenLocal()
     mavenCentral()
-    maven { url "https://dev.saxonica.com/maven" }
+    maven { url "https://maven.saxonica.com/maven" }
   }
 
   configurations.all {
@@ -39,7 +39,7 @@ import com.nwalsh.gradle.docker.DockerContainer
 repositories {
   mavenLocal()
   mavenCentral()
-  maven { url "https://dev.saxonica.com/maven" }
+  maven { url "https://maven.saxonica.com/maven" }
 }
 
 configurations.all {
@@ -69,21 +69,34 @@ dependencies {
   implementation (
     [group: 'com.beust', name: 'jcommander', version: '1.81' ],
     [group: 'org.fusesource.jansi', name: 'jansi', version: '2.4.0'],
-    [group: saxonGroup, name: saxonEdition, version: saxonVersion],
     fileTree(dir: "${projectDir}/lib", include: '*.jar')
   )
+
+  implementation ("${saxonGroup}:${saxonEdition}") {
+    exclude group: "net.sf.saxon", module: "Saxon-HE"
+    version {
+      strictly "${saxonVersion}"
+    }
+  }
+
   documentation (
     project(':coffeegrinder'),
     project(':coffeefilter'),
     project(':coffeesacks'),
     [group: 'com.beust', name: 'jcommander', version: '1.81' ],
     [group: 'org.fusesource.jansi', name: 'jansi', version: '2.4.0'],
-    [group: saxonGroup, name: saxonEdition, version: saxonVersion],
     [group: 'org.docbook', name: 'schemas-docbook', version: docbookVersion],
     [group: 'org.docbook', name: 'docbook-xslTNG', version: xslTNGversion],
     [group: 'com.saxonica', name: 'xmldoclet', version: xmldocletVersion],
     fileTree(dir: "${projectDir}/lib", include: '*.jar')
   )
+
+  documentation("${saxonGroup}:${saxonEdition}") {
+    exclude group: "net.sf.saxon", module: "Saxon-HE"
+    version {
+      strictly "${saxonVersion}"
+    }
+  }
 }
 
 testing {

--- a/coffeesacks/build.gradle
+++ b/coffeesacks/build.gradle
@@ -2,7 +2,7 @@ buildscript {
   repositories {
     mavenLocal()
     mavenCentral()
-    maven { url "https://dev.saxonica.com/maven" }
+    maven { url "https://maven.saxonica.com/maven" }
   }
 
   configurations.all {
@@ -40,7 +40,7 @@ import java.nio.file.Files
 repositories {
   mavenLocal()
   mavenCentral()
-  maven { url "https://dev.saxonica.com/maven" }
+  maven { url "https://maven.saxonica.com/maven" }
 }
 
 configurations.all {
@@ -58,9 +58,14 @@ configurations {
 dependencies {
   implementation project(':coffeegrinder')
   implementation project(':coffeefilter')
-  implementation (
-    [group: 'net.sf.saxon', name: 'Saxon-HE', version: saxonVersion],
-  )
+
+  implementation ("${saxonGroup}:${saxonEdition}") {
+    exclude group: "net.sf.saxon", module: "Saxon-HE"
+    version {
+      strictly "${saxonVersion}"
+    }
+  }
+
   documentation (
     project(':coffeegrinder'),
     project(':coffeefilter'),
@@ -69,6 +74,13 @@ dependencies {
     [group: 'org.docbook', name: 'docbook-xslTNG', version: xslTNGversion],
     [group: 'com.saxonica', name: 'xmldoclet', version: xmldocletVersion],
   )
+
+  documentation("${saxonGroup}:${saxonEdition}") {
+    exclude group: "net.sf.saxon", module: "Saxon-HE"
+    version {
+      strictly "${saxonVersion}"
+    }
+  }
 }
 
 testing {

--- a/documentation/build.gradle
+++ b/documentation/build.gradle
@@ -2,7 +2,7 @@ buildscript {
   repositories {
     mavenLocal()
     mavenCentral()
-    maven { url "https://dev.saxonica.com/maven" }
+    maven { url "https://maven.saxonica.com/maven" }
   }
 
   configurations.all {
@@ -36,7 +36,7 @@ import com.nwalsh.gradle.docker.DockerContainer
 repositories {
   mavenLocal()
   mavenCentral()
-  maven { url "https://dev.saxonica.com/maven" }
+  maven { url "https://maven.saxonica.com/maven" }
 }
 
 configurations.all {

--- a/nineml-org/build.gradle
+++ b/nineml-org/build.gradle
@@ -2,7 +2,7 @@ buildscript {
   repositories {
     mavenLocal()
     mavenCentral()
-    maven { url "https://dev.saxonica.com/maven" }
+    maven { url "https://maven.saxonica.com/maven" }
   }
 
   configurations.all {
@@ -36,7 +36,7 @@ import com.nwalsh.gradle.docker.DockerContainer
 repositories {
   mavenLocal()
   mavenCentral()
-  maven { url "https://dev.saxonica.com/maven" }
+  maven { url "https://maven.saxonica.com/maven" }
 }
 
 configurations.all {


### PR DESCRIPTION
There’s a transient dependency on Saxon 9.6.0-4 in some part of the RELAX NG implementation. If that leaks into the build, bad happens. Sometimes.