### PR TITLE
Tweak CI builds so that they work

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -92,11 +92,11 @@ jobs:
         run: |
           curl -s -o `pwd`/secret.gpg ${{ secrets.GPGKEYURI }}
           echo "Start build distribution"
-          ./gradlew -PparserType=earley -PsaxonGroup=com.saxonica -PsaxonEdition=Saxon-EE \
+          ./gradlew -PparserType=earley \
                     -Psigning.keyId="${{ secrets.SIGNKEY }}" \
                     -Psigning.password="${{ secrets.SIGNPSW }}" \
                     -Psigning.secretKeyRingFile=`pwd`/secret.gpg \
-                    clean dist docset website
+                    clean dist docset website mavenReleaseArtifact
           rm -f `pwd`/secret.gpg
 
       - name: Publish coffeegrinder release

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -93,4 +93,4 @@ jobs:
         run: |
           ./gradlew clean
           echo "Start build distribution"
-          ./gradlew -PparserType=earley -PsaxonGroup=com.saxonica -PsaxonEdition=Saxon-EE dist docset website
+          ./gradlew -PparserType=earley dist docset website

--- a/coffeefilter/build.gradle
+++ b/coffeefilter/build.gradle
@@ -398,7 +398,6 @@ task mavenReleaseArtifact(type: Zip) {
   from(layout.buildDirectory.dir("maven"))
   archiveFileName = "maven-coffeefilter-${ninemlVersion}.zip"
 }
-zipDist.finalizedBy mavenReleaseArtifact
 
 signing {
   sign publishing.publications

--- a/coffeegrinder/build.gradle
+++ b/coffeegrinder/build.gradle
@@ -205,7 +205,6 @@ task mavenReleaseArtifact(type: Zip) {
   from(layout.buildDirectory.dir("maven"))
   archiveFileName = "maven-coffeegrinder-${ninemlVersion}.zip"
 }
-zipDist.finalizedBy mavenReleaseArtifact
 
 signing {
   sign publishing.publications

--- a/coffeepot/build.gradle
+++ b/coffeepot/build.gradle
@@ -294,7 +294,6 @@ task mavenReleaseArtifact(type: Zip) {
   from(layout.buildDirectory.dir("maven"))
   archiveFileName = "maven-coffeepot-${ninemlVersion}.zip"
 }
-zipDist.finalizedBy mavenReleaseArtifact
 
 signing {
   sign publishing.publications

--- a/coffeesacks/build.gradle
+++ b/coffeesacks/build.gradle
@@ -274,7 +274,6 @@ task mavenReleaseArtifact(type: Zip) {
   from(layout.buildDirectory.dir("maven"))
   archiveFileName = "maven-coffeesacks-${ninemlVersion}.zip"
 }
-zipDist.finalizedBy mavenReleaseArtifact
 
 signing {
   sign publishing.publications


### PR DESCRIPTION
The PR build required signing, which it doesn’t have. Fixing that meant also fixing the release build so that it will construct the maven release artifacts.