### PR TITLE
Avoid non-XML characters in failure documents

### DIFF
--- a/coffeefilter/src/main/java/org/nineml/coffeefilter/InvisibleXmlFailureDocument.java
+++ b/coffeefilter/src/main/java/org/nineml/coffeefilter/InvisibleXmlFailureDocument.java
@@ -102,6 +102,15 @@ public class InvisibleXmlFailureDocument extends InvisibleXmlDocument {
                         }
                         handler.startElement("", "unexpected", "unexpected", attrs);
                         String value = tchar.getValue();
+
+                        int cp = tchar.getCodepoint();
+                        if (!(cp == '\t' || cp == '\n' || cp == '\r'
+                                || (cp >= 0x20 && cp <= 0xD7FF)
+                                || (cp >= 0xE00 && cp <= 0xFFFD)
+                                || (cp >= 0x10000 && cp <= 0x10FFFF))) {
+                            value = String.format("U+%04X", cp);
+                        }
+
                         handler.characters(value.toCharArray(), 0, value.length());
                         handler.endElement("", "unexpected", "unexpected");
                     } else {

--- a/coffeefilter/src/test/java/org/nineml/coffeefilter/ParserFailTest.java
+++ b/coffeefilter/src/test/java/org/nineml/coffeefilter/ParserFailTest.java
@@ -49,4 +49,48 @@ public class ParserFailTest {
             System.err.println(ex.getMessage());
         }
     }
+
+    @Test
+    public void nonXmlChars() {
+        String input = "date: s?, day, -s, month, (-s, year)? .\n" +
+                "-s: -\" \"+ .\n" +
+                "day: digit, digit? .\n" +
+                "-digit: \"0\"; \"1\"; \"2\"; \"3\"; \"4\"; \"5\"; \"6\"; \"7\"; \"8\"; \"9\".\n" +
+                "month: \"January\"; \"February\"; \"March\"; \"April\";\n" +
+                "       \"May\"; \"June\"; \"July\"; \"August\";\n" +
+                "       \"September\"; \"October\"; \"November\"; \"December\".\n" +
+                "year: ((digit, digit); -\"'\")?, digit, digit .";
+
+        InvisibleXmlParser parser = invisibleXml.getParserFromIxml(input);
+
+        input = "16 \u0001 1992";
+        InvisibleXmlDocument doc = parser.parse(input);
+
+        Processor processor = new Processor(false);
+        DocumentBuilder builder = processor.newDocumentBuilder();
+
+        try {
+            BuildingContentHandler bch = builder.newBuildingContentHandler();
+            doc.getTree(bch);
+            XdmNode node = bch.getDocumentNode();
+
+            String str = node.toString();
+            if (doc.getParserType() == ParserType.Earley) {
+                Assertions.assertTrue(str.contains("<line>1</line>"));
+                Assertions.assertTrue(str.contains("<column>4</column>"));
+                Assertions.assertTrue(str.contains("<pos>4</pos>"));
+                Assertions.assertTrue(str.contains(" <unexpected codepoint=\"#0001\">U+0001</unexpected>"));
+                Assertions.assertTrue(str.contains("<permitted>' ', 'A', 'D', 'F', 'J', 'M', 'N', 'O', 'S'</permitted>"));
+            }
+            if (doc.getParserType() == ParserType.GLL) {
+                Assertions.assertTrue(str.contains("<line>1</line>"));
+                Assertions.assertTrue(str.contains("<column>4</column>"));
+                Assertions.assertTrue(str.contains("<pos>4</pos>"));
+                Assertions.assertTrue(str.contains(" <unexpected codepoint=\"#0001\">U+0001</unexpected>"));
+            }
+        } catch (SaxonApiException ex) {
+            System.err.println(ex.getMessage());
+        }
+    }
+
 }


### PR DESCRIPTION
Fix #79

When a non-XML character causes a parse to fail, its representation in the failure document is "0xNNNN" where "NNNN" is its codepoint. That’s not a standard representation, but "&#xNNNN;" makes the failure document unparseable.