### PR TITLE
Throw a specific error code in CoffeeSacks when the parse fails

### DIFF
--- a/coffeefilter/src/test/java/org/nineml/coffeefilter/ModularityTest.java
+++ b/coffeefilter/src/test/java/org/nineml/coffeefilter/ModularityTest.java
@@ -7,7 +7,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.nineml.coffeefilter.exceptions.IxmlException;
+import org.xml.sax.InputSource;
 
+import javax.xml.transform.sax.SAXSource;
 import java.io.File;
 import java.io.IOException;
 
@@ -174,7 +176,8 @@ public class ModularityTest {
         XsltCompiler compiler = processor.newXsltCompiler();
 
         if (transpiler == null) {
-            XsltExecutable exec = compiler.compile(new File("src/test/resources/schxslt2-1.4.4/transpile.xsl"));
+            SAXSource source = new SAXSource(new InputSource("src/test/resources/schxslt2-1.4.4/transpile.xsl"));
+            XsltExecutable exec = compiler.compile(source);
             transpiler = exec.load();
         }
 

--- a/coffeesacks/src/main/java/org/nineml/coffeesacks/CoffeeSacksException.java
+++ b/coffeesacks/src/main/java/org/nineml/coffeesacks/CoffeeSacksException.java
@@ -24,6 +24,7 @@ public class CoffeeSacksException extends XPathException {
     public static final String ERR_INVALID_CHOICE = "CSIF0002";
     public static final String ERR_TREE_CONSTRUCTION = "CSIN0001";
     public static final String ERR_NAMESPACE_CONSTRUCTION = "CSIN0002";
+    public static final String PARSE_FAILED = "CSPA0001";
 
     public CoffeeSacksException(String errCode, String message) {
         super(message);

--- a/coffeesacks/src/main/java/org/nineml/coffeesacks/CommonDefinition.java
+++ b/coffeesacks/src/main/java/org/nineml/coffeesacks/CommonDefinition.java
@@ -8,10 +8,7 @@ import net.sf.saxon.functions.CallableFunction;
 import net.sf.saxon.lib.ExtensionFunctionDefinition;
 import net.sf.saxon.ma.map.MapItem;
 import net.sf.saxon.ma.map.MapType;
-import net.sf.saxon.om.GroundedValue;
-import net.sf.saxon.om.Item;
-import net.sf.saxon.om.NodeInfo;
-import net.sf.saxon.om.Sequence;
+import net.sf.saxon.om.*;
 import net.sf.saxon.pattern.NodeKindTest;
 import net.sf.saxon.s9api.*;
 import net.sf.saxon.trans.XPathException;
@@ -490,7 +487,13 @@ public abstract class CommonDefinition extends ExtensionFunctionDefinition {
                 if (document instanceof InvisibleXmlFailureDocument) {
                     InvisibleXmlFailureDocument failure = (InvisibleXmlFailureDocument) document;
                     String message = failure.getTree();
-                    throw new XPathException(message);
+
+                    StructuredQName errCode = new StructuredQName(CoffeeSacksException.COFFEE_SACKS_ERROR_PREFIX,
+                            CoffeeSacksException.COFFEE_SACKS_ERROR_NAMESPACE,
+                            CoffeeSacksException.PARSE_FAILED);
+                    XPathException ex = new XPathException(message);
+                    ex.setErrorCodeQName(errCode);
+                    throw ex;
                 }
 
                 final XmlForest forest;

--- a/coffeesacks/src/test/java/org/nineml/coffeesacks/StylesheetTests.java
+++ b/coffeesacks/src/test/java/org/nineml/coffeesacks/StylesheetTests.java
@@ -253,4 +253,21 @@ public class StylesheetTests extends TestConfiguration {
         Assertions.assertEquals("<doc><S>a</S></doc>", xml);
     }
 
+    @Test
+    public void errorCodeX() {
+        XdmNode stylesheet = loadStylesheet("src/test/resources/error-code.xsl");
+
+        Map<String,String> params = new HashMap<>();
+        params.put("start-symbol", "S");
+
+        try {
+            XdmNode result = transform(stylesheet, stylesheet, params);
+            String xml = serialize(result);
+            Assertions.assertEquals("<pass/>", xml);
+        } catch (Exception ex) {
+            fail();
+        }
+    }
+
+
 }

--- a/coffeesacks/src/test/resources/error-code.xsl
+++ b/coffeesacks/src/test/resources/error-code.xsl
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:cs="http://nineml.com/ns/coffeesacks"
+                xmlns:cse="http://nineml.com/ns/coffeesacks/errors"
+                xmlns:err="http://www.w3.org/2005/xqt-errors"
+                xmlns:f="http://coffeesacks.nineml.com/fn/testing"
+                xmlns:map="http://www.w3.org/2005/xpath-functions/map"
+                exclude-result-prefixes="#all"
+                version="3.0">
+
+<xsl:param name="start-symbol" select="()"/>
+
+<xsl:output method="xml" encoding="utf-8" indent="no"/>
+
+<xsl:mode on-no-match="shallow-copy"/>
+
+<xsl:template match="/">
+  <xsl:try>
+    <xsl:variable name="parser" select="cs:make-parser('S = ''a''|B. B=''a''.',
+                                        map {'start-symbol': $start-symbol })"/>
+    <doc>
+      <xsl:sequence select="$parser('c')"/>
+    </doc>
+    <xsl:catch errors="cse:CSPA0001">
+      <pass/>
+    </xsl:catch>
+    <xsl:catch>
+      <fail/>
+    </xsl:catch>
+  </xsl:try>
+</xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
Fix #80

I was throwing specific error codes for grammar parsing problems, but not for input parsing problems. CoffeeSacks now throws

  Q{http://nineml.com/ns/coffeesacks/errors}CSPA0001

for parse failure